### PR TITLE
Changed eventmanager to match the publish/subscribe pattern

### DIFF
--- a/eventmanagerTests.html
+++ b/eventmanagerTests.html
@@ -61,11 +61,11 @@
 		var that = this;
 		$("button", this.rootEl).click(function()
 										{
-											that.eventManager.fire(that, that.pressedEventId);
+											that.eventManager.publish(that.pressedEventId);
 										} );
 		
-		// Define private callbacks for subscribed events
-		function pressedCallback()
+		// Define private handlers for subscribed events
+		function pressedHandler()
 		{
 			var button = $('button', that.rootEl);
 			var color = button.css('background-color');
@@ -73,11 +73,8 @@
 			button.css('background-color', newColor);
 		}
 		
-		// Publish events a ButtonWidget may fire
-		eventManager.publish(this, this.pressedEventId);
-		
 		// Subscribe to events the ButtonWidget responds to
-		eventManager.subscribe(this.pressedEventId, pressedCallback);
+		eventManager.subscribe(this.pressedEventId, pressedHandler);
 	}
 	
 	ButtonWidget.prototype.setText = function(text)


### PR DESCRIPTION
The event manager is much simpler now, I think it matches the intent of the email Leslie got. I hadn't seen the publish/subscribe terminology before I googled it today while re-reading the sample code in the email.
