### PR TITLE
Allow widgets to be appended to LineGraph

### DIFF
--- a/js/widget-base.js
+++ b/js/widget-base.js
@@ -74,6 +74,17 @@ function Rect(x, y, width, height)
 	this.right = this.left + width;
 }
 
+/* **************************************************************************
+ * Rect.getSize                                                         *//**
+ *
+ * Get the size of this rect in a Size object.
+ *
+ * @return {Size}
+ ****************************************************************************/
+ Rect.prototype.getSize = function ()
+ {
+	return { height: this.height, width: this.width };
+ };
 
 /* **************************************************************************
  * Rect.makeRect - static                                               *//**
@@ -192,6 +203,15 @@ IWidget = function () {};
  *
  ****************************************************************************/
 IWidget.prototype.draw = function (container, size) {};
+
+/* **************************************************************************
+ * IWidget.redraw                                                       *//**
+ *
+ * Redraw the widget assuming its data may have been modified. It will be
+ * redrawn into the same container area as it was last drawn.
+ *
+ ****************************************************************************/
+IWidget.prototype.redraw = function () {};
 
 /* **************************************************************************
  * IWidget.setScale                                                     *//**

--- a/js/widget-labelgroup.js
+++ b/js/widget-labelgroup.js
@@ -256,6 +256,26 @@ LabelGroup.prototype.draw = function(container, size)
 	this.lastdrawn.labelCollection = labelsContainer.selectAll("g.label");
 }; // end of LabelGroup.draw()
 
+/* **************************************************************************
+ * LabelGroup.setScale                                                  *//**
+ *
+ * Called to preempt the normal scale definition which is done when the
+ * widget is drawn. This is usually called in order to force one widget
+ * to use the scaling/data area calculated by another widget.
+ *
+ * @param {function(number): number}
+ *						xScale	-function to convert a horizontal data offset
+ *								 to the pixel offset into the data area.
+ * @param {function(number): number}
+ *						yScale	-function to convert a vertical data offset
+ *								 to the pixel offset into the data area.
+ *
+ ****************************************************************************/
+LabelGroup.prototype.setScale = function (xScale, yScale)
+{
+	this.explicitScales_.xScale = xScale;
+	this.explicitScales_.yScale = yScale;
+};
 
 /* **************************************************************************
  * LabelGroup.labelLite                                                 *//**

--- a/lineGraphTests.html
+++ b/lineGraphTests.html
@@ -54,6 +54,7 @@
 	<script src="js/widget-base.js"></script>
 	<script src="js/widget-linegraph.js"></script>
     <script src="js/widget-legend.js"></script>
+    <script src="js/widget-labelgroup.js"></script>
 
 <script>
 	var testData = [
@@ -460,6 +461,19 @@
 						   label: "Human Population (Billions)" },
 		};
 
+	var lblGrpConfig80 = {
+			id: "lbls80",
+			type: "numbered",
+			labels: 	
+			[
+				{ content: "TOP left",		xyPos: [1960, 3],	width: 100	},
+				{ content: "middle left",	xyPos: [1980, 4.5],	width: 100	},
+				{ content: "Bottom left" ,	xyPos: [2013, 7],	width: 100	},
+			]
+		};
+
+	var labelGroup80 = new LabelGroup(lblGrpConfig80);
+
 	cntr[n] = new SVGContainer(config[n].cntr);
 	lineGraph[n] = new LineGraph(config[n].lg);
 	
@@ -470,7 +484,9 @@
 		type: "line"
 	});
 	
-	cntr[n].append([lineGraph[n],legLines], {topPercentOffset: 0, leftPercentOffset: 0, heightPercent: 1, widthPercent: 1});
+	cntr[n].append([lineGraph[n], legLines], {topPercentOffset: 0, leftPercentOffset: 0, heightPercent: 1, widthPercent: 1});
+	
+	lineGraph[n].append(labelGroup80);
 
     var litekey = [0,1,2];
  


### PR DESCRIPTION
OK, this seems to be working.
I've created a tiny sample test case of appending a label group to a line graph in `lineGraphTests.html` (see code below) which I'm hoping you (Leslie) will clean up with a better test.

``` javascript
var lblGrpConfig80 = {...};

var labelGroup80 = new LabelGroup(lblGrpConfig80);

cntr[n] = new SVGContainer(config[n].cntr);
lineGraph[n] = new LineGraph(config[n].lg);

var legLines = new Legend({...});

cntr[n].append([lineGraph[n], legLines], {topPercentOffset: 0, leftPercentOffset: 0, heightPercent: 1, widthPercent: 1});

lineGraph[n].append(labelGroup80);
```

Although I haven't tested it; you should be able to append to the LineGraph before you append the LineGraph to the container if you want.
