### PR TITLE
carousel widget and demo of image viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Files we don't want in *this* repository #
+############################################
+# Windows shortcut files
+*.lnk
+
 # Compiled source #
 ###################
 *.com

--- a/css/widgets.css
+++ b/css/widgets.css
@@ -40,6 +40,20 @@ svg g.widgetCarousel>rect.background
 	fill-opacity:	0.0;
 }
 
+svg g.widgetCarousel>g.widgetItem>rect.selection
+{
+	fill:			#4f00ef;
+	fill-opacity:	0.0;
+	stroke:			blue;
+	stroke-opacity:	0.0;	
+}
+
+svg g.widgetCarousel>g.widgetItem.selected>rect.selection
+{
+	fill-opacity:	0.1;
+	stroke-opacity:	0.8;	
+}
+
 
 /* Labels
 ================================================== */

--- a/imageTests.html
+++ b/imageTests.html
@@ -19,7 +19,7 @@
                 <h2 class="setTitle"></h2>
 				<div id="widgetTarget0n"><p>0n. Single image</p></div>
 				<div id="widgetTarget0"><p>0. Single image</p></div>
-				<div id="widgetTarget1n"><p>1n. Multiple images with autoCarousel (events)</p></div>
+				<div id="widgetTarget1n"><p>1n. Multiple images in 2 Carousels the top one gets lite events, the bottom doesn't</p></div>
 				<div id="widgetTarget1"><p>1. Multiple images with autoCarousel (events)</p></div>
 				<div id="widgetTarget2"><p>2. Image with graph overlay on local coordinate system (set by data in graph)</p></div>
 				
@@ -132,42 +132,38 @@
 	var imgConfig1 =
 		[
 			{
-				id: "img10n",
 				URI: 'img/ch4_0_1.png',
 				caption: "Earth's atmosphere. &copy;NASA http://www.nasa.gov/multimedia/imagegallery/ image_feature_1529.html",
 				preserveAspectRatio: "xMidYMid",
 				actualSize: {height: 710, width: 946}
 			},
 			{
-				id: "img11n",
 				URI: 'img/ch4_03.jpg',
 				caption: "The seasons",
 				preserveAspectRatio: "xMidYMid",
 				actualSize: {height: 366, width: 443}
 			},
 			{
-				id: "img12n",
 				URI: 'img/ch4_0_2.jpg',
 				caption: "Heat transfer mechanisms",
 				preserveAspectRatio: "xMidYMid",
-				actualSize: {height: 443, width: 160}
+				actualSize: {height: 443, width: 160},
+				key: 'foo'
 			},
 			{
-				id: "img13n",
 				URI: 'img/ch4_1.jpg',
 				caption: "The Whitewater-Baldy Complex wildfire.",
 				preserveAspectRatio: "xMidYMid",
 				actualSize: {height: 960, width: 1280}
 			},
 			{
-				id: "img14n",
 				URI: 'img/ch4_2.jpg',
 				caption: "Aerial image near downtown West Liberty, Kentucky.",
 				preserveAspectRatio: "xMidYMid",
-				actualSize: {height: 550, width: 550}
+				actualSize: {height: 550, width: 550},
+				key: 'foo'
 			},
 			{
-				id: "img15n",
 				URI: 'img/ch4_4.jpg',
 				caption: "Seaside Heights, NJ after Hurricane Sandy.",
 				preserveAspectRatio: "xMidYMid",
@@ -177,7 +173,6 @@
 
 	var crslConfig1 =
 		{
-			id: "crsl1",
 			items:
 				[
 					new Image(imgConfig1[0]),
@@ -193,17 +188,38 @@
 			scrollMode: "nowrap"
 		};
 		
+	var crslConfig2 =
+		{
+			items:
+				[
+					new Image(imgConfig1[5]),
+					new Image(imgConfig1[4]),
+					new Image(imgConfig1[3]),
+					new Image(imgConfig1[2]),
+					new Image(imgConfig1[1]),
+					new Image(imgConfig1[0])
+				],
+			layout: "horizontal",
+			itemMargin: {top: 4, bottom: 4, left: 2, right: 2},
+			presentation: "scaleToFit", // or "scroll"
+			scrollMode: "nowrap"
+		};
+		
 	var cntrConfig1 = 
 		{
 			node: d3.select("#widgetTarget1n"),
 			maxWid: 400,
-			maxHt: 75
+			maxHt: 160
 		};
 
 	var cntr1 = new SVGContainer(cntrConfig1);
 	var crsl1 = new Carousel(crslConfig1, eventManager);
+	var crsl2 = new Carousel(crslConfig2, eventManager);
 	
-	cntr1.append(crsl1, {topPercentOffset: 0, leftPercentOffset: 0, heightPercent: 1, widthPercent: 1});
+	cntr1.append(crsl1, {topPercentOffset: 0, leftPercentOffset: 0, heightPercent: 0.45, widthPercent: 1});
+	cntr1.append(crsl2, {topPercentOffset: 0.55, leftPercentOffset: 0, heightPercent: 0.45, widthPercent: 1});
+
+	eventManager.subscribe(crsl1.selectedEventId, function (eventDetails) {crsl1.lite(eventDetails.selectKey);});
 
 // Old widgets code test for widget 1
 	var svg1 = new MakeSVGContainer(

--- a/imageTests.html
+++ b/imageTests.html
@@ -20,6 +20,7 @@
 				<div id="widgetTarget0n"><p>0n. Single image</p></div>
 				<div id="widgetTarget0"><p>0. Single image</p></div>
 				<div id="widgetTarget1n"><p>1n. Multiple images in 2 Carousels the top one gets lite events, the bottom doesn't</p></div>
+				<div id="widgetTarget1an"><p>1an. Multiple image carousel selection shown larger.</p></div>
 				<div id="widgetTarget1"><p>1. Multiple images with autoCarousel (events)</p></div>
 				<div id="widgetTarget2"><p>2. Image with graph overlay on local coordinate system (set by data in graph)</p></div>
 				
@@ -220,6 +221,50 @@
 	cntr1.append(crsl2, {topPercentOffset: 0.55, leftPercentOffset: 0, heightPercent: 0.45, widthPercent: 1});
 
 	eventManager.subscribe(crsl1.selectedEventId, function (eventDetails) {crsl1.lite(eventDetails.selectKey);});
+
+	var crslConfig3 =
+		{
+			items:
+				[
+					new Image(imgConfig1[0]),
+					new Image(imgConfig1[1]),
+					new Image(imgConfig1[2]),
+					new Image(imgConfig1[3]),
+					new Image(imgConfig1[4]),
+					new Image(imgConfig1[5])
+				],
+			layout: "horizontal",
+			itemMargin: {top: 4, bottom: 4, left: 2, right: 2},
+			presentation: "scaleToFit", // or "scroll"
+			scrollMode: "nowrap"
+		};
+
+	var cimgConfig3 =
+		{
+			image: new Image(imgConfig1[0])
+		};
+
+	var cntrConfig3 = 
+		{
+			node: d3.select("#widgetTarget1an"),
+			maxWid: 400,
+			maxHt: 400
+		};
+
+	var cntr3 = new SVGContainer(cntrConfig3);
+	var crsl3 = new Carousel(crslConfig3, eventManager);
+	var cimg3 = new CaptionedImage(cimgConfig3, eventManager);
+	
+	cntr3.append(crsl3, {topPercentOffset: 0, leftPercentOffset: 0, heightPercent: 0.20, widthPercent: 1});
+	cntr3.append(cimg3, {topPercentOffset: 0.20, leftPercentOffset: 0, heightPercent: 0.75, widthPercent: 1});
+	 
+	var handleImageView = function (eventDetails)
+	{
+		cimg3.changeImage(crsl3.selectedItem().URI, crsl3.selectedItem().caption);
+		cimg3.redraw();
+	};
+
+	eventManager.subscribe(crsl3.selectedEventId, handleImageView);
 
 // Old widgets code test for widget 1
 	var svg1 = new MakeSVGContainer(

--- a/js/widget-carousel.js
+++ b/js/widget-carousel.js
@@ -127,10 +127,6 @@ function Carousel(config, eventManager)
 	 * @property {string} selectKey	-The key associated with the selected item.
 	 */
 
-	// TODO: Using the selection event may not be the way we want to set highlighting internally
-	// because I'm not sure if 2 items have the same key we still want to highlight both?
-	eventManager.subscribe(this.selectedEventId, function (eventDetails) {that.lite(eventDetails.selectKey);});
-	 
 	/**
 	 * Information about the last drawn instance of this image (from the draw method)
 	 * @type {Object}
@@ -214,19 +210,26 @@ Carousel.prototype.draw = function(container, size)
 			.each(function (d)
 				  {
 					  d.draw(d3.select(this), itemSize);
-				  });
+				  })
+			.append("rect")
+				.attr("class", "selection")
+				.attr("width", itemSize.width + 2)
+				.attr("height", itemSize.height + 2)
+				.attr("stroke-width", 2)
+				.attr("x", -1)
+				.attr("y", -1);
 	
 	// position each item
 	itemGroups
 		.attr("transform", translateItem);
 
 	itemGroups.on('click',
-				  function (d)
+				  function (d, i)
 				  {
-					  that.eventManager.publish(that.selectedEventId, {selectKey: d.key});
+					  that.selectItemAtIndex(i);
 				  });
 				
-	this.widgetGroup = widgetGroup;
+	this.lastdrawn.widgetGroup = widgetGroup;
 
 }; // end of Carousel.draw()
 
@@ -246,6 +249,25 @@ Carousel.prototype.redraw = function ()
 	
 	var desc = image.select("desc");
 	desc.text(this.caption);
+};
+
+/* **************************************************************************
+ * Carousel.selectItemAtIndex                                           *//**
+ *
+ * Select the item in the carousel at the given index.
+ *
+ * @param {number}	index	-the 0-based index of the item to flag as selected.
+ *
+ ****************************************************************************/
+Carousel.prototype.selectItemAtIndex = function (index)
+{
+	var itemGroups = this.lastdrawn.widgetGroup.selectAll("g.widgetItem");
+	itemGroups.classed("selected", false);
+
+	var selectedItemGroup = d3.select(itemGroups[0][index]);
+	selectedItemGroup.classed("selected", true);
+
+	this.eventManager.publish(this.selectedEventId, {selectKey: selectedItemGroup.datum().key});
 };
 
 /* **************************************************************************

--- a/js/widget-carousel.js
+++ b/js/widget-carousel.js
@@ -252,6 +252,19 @@ Carousel.prototype.redraw = function ()
 };
 
 /* **************************************************************************
+ * Carousel.selectedItem                                                *//**
+ *
+ * Return the selected item in the carousel.
+ *
+ * @return {Object} the carousel item which is currently selected.
+ *
+ ****************************************************************************/
+Carousel.prototype.selectedItem = function ()
+{
+	return this.lastdrawn.widgetGroup.select("g.widgetItem.selected").datum();
+};
+
+/* **************************************************************************
  * Carousel.selectItemAtIndex                                           *//**
  *
  * Select the item in the carousel at the given index.

--- a/js/widget-image.js
+++ b/js/widget-image.js
@@ -232,7 +232,7 @@ Image.prototype.redraw = function ()
 {
 	// TODO: Do we want to allow calling redraw before draw (ie handle it gracefully
 	//       by doing nothing? -mjl
-	var image = this.widgetGroup.select("image");
+	var image = this.lastdrawn.widgetGroup.select("image");
 	image.attr("xlink:href", this.URI);
 	
 	var desc = image.select("desc");
@@ -554,7 +554,10 @@ CaptionedImage.prototype.redraw = function ()
 	//       by doing nothing? -mjl
 	this.image.redraw();
 
-	var captionDiv = this.lastdrawn.widgetGroup.select("g foreignObject div")
+	// NOTE: for some reason foreignObject in a d3 selector doesn't work
+	//       but body does.
+	// TODO: updating the html isn't causing it to be re-rendered (at least in Chrome)
+	var captionDiv = this.lastdrawn.widgetGroup.select("g body div")
 		.html(this.image.caption);
 };
 


### PR DESCRIPTION
Carousel widget has selection working.
And I've build a proof of concept image viewer (select image with carousel, update other image with selection).

I know that that configuration is common enough that we probably want to create an ImageViewer widget that encapsulates what needs to be done to set it up.

There is 1 issue I haven't figured out yet. It seems that updating the div in the foreignObject doesn't cause it to re-render. It will re-render if you scroll it away and back.
