### PR TITLE
enhance RadioGroup

### DIFF
--- a/multiChoiceTests.html
+++ b/multiChoiceTests.html
@@ -21,6 +21,11 @@
 				<div><p>0. Radio button w/ 4 answers</p>
 					<p>Q1: Why?</p>
 					<div id="rb-test" style="margin: 0 0 15px 15px;"/>
+						<p>In order to manually test that selecting an answer correctly
+						publishes the selected event, we have an event handler that displays
+						the answer key of the selection. It should change as you manually
+						select an answer.</p>
+						<p>The answer key selected is: <b id="rb-test-key">none</b>.</p>
 				</div>
 				<div id="radioRnd"><p>1. Multiple Choice question, randomized</p></div>
 				<div id="radioOrd"><p>2. Multiple Choice question, nonrandomized</p></div>
@@ -28,7 +33,7 @@
 
 			</div>
 			<div class="span6 rightCol">
-				<div id="graphIn"><p>4. Graphs as responsesn (radio buttons containing widgets)</p></div>
+				<div id="graphIn"><p>4. Graphs as responses (radio buttons containing widgets)</p></div>
 				<div id="graphIn"><p>5. Traces as responses (choose a trace)</p></div>
 	
 			</div>
@@ -83,10 +88,19 @@
 			id: "RG1",
 			choices: Q1Choices,
 			numberFormat: "number"
-		});
+		}, eventManager);
 
 	radioButtons.draw(d3.select("#rb-test"));
 
+	// Manual test that making a selection on the radio group fires the selectedEventId
+	var handle_radioButtons_selected = function (eventDetails)
+	{
+		d3.select("#rb-test-key").text(eventDetails.selectKey);
+	};
+
+	eventManager.subscribe(radioButtons.selectedEventId, handle_radioButtons_selected);
+
+	// Test a select one question using a radio group widget
 	var Q1 = new RadioGroupQuestion({
 			id: "Q1",
 			question: "Wherefore?",

--- a/test/README.md
+++ b/test/README.md
@@ -38,3 +38,15 @@ falls down when you run the tests in IE sometimes.
 [karma]: <http://karma-runner.github.io/0.8/index.html> "Karma Spectacular Test Runner for JavaScript"
 [node.js]: <http://nodejs.org/> "node.js home page"
 [phantomjs]: <http://phantomjs.org/> "phantom.js home page"
+
+## Environment setup ##
+### linux ###
+
+Install node and phantomjs. 
+The npm package depends on the nodejs package (among others).
+
+    $ sudo apt-get install npm phantomjs
+
+Then use npm (node package manager) to install karma:
+
+    $ sudo npm install -g karma

--- a/test/spec/widget-radiogroup-spec.js
+++ b/test/spec/widget-radiogroup-spec.js
@@ -111,9 +111,13 @@
                 expect(myRadioGroup.choices[3]).to.not.have.property('key');
             });
 
-            it('should leave existing keys on images unchanged', function () {
+            it('should leave existing keys on choices unchanged', function () {
                 expect(myRadioGroup.choices[1]).to.have.property('key', 'foo').that.is.a('string');
             });
+
+			it('should have the eventManager given to the constructor', function () {
+                expect(myRadioGroup.eventManager).to.equal(eventManager);
+			});
 
 			it('should have an uninitialized lastdrawn property', function () {
                 expect(myRadioGroup.lastdrawn).to.have.property('container').that.is.null;
@@ -148,7 +152,6 @@
 						expect(myRadioGroup.lastdrawn.widgetGroup.node()).to.deep.equal(last.node());
 					});
 
-					// todo: Implement this test. -mjl
 					it('should create a table w/ a row for each choice', function () {
 						/*
 						 div.widgetRadioGroup
@@ -190,12 +193,24 @@
 					});
 				});
 
-				describe.skip('.selectItemAtIndex()', function () {
+				describe('.selectItemAtIndex()', function () {
 					it('should publish the radiogroup.selectedEventId with the answer key of the item at that index', function () {
 						var prevSelectEventCount = selectEventCount;
 						myRadioGroup.selectItemAtIndex(1);
 						expect(selectEventCount).is.equal(prevSelectEventCount + 1);
-						expect(lastSelectEventDetails.selectKey).is.equal('foo');
+						expect(lastSelectEventDetails.selectKey).is.equal('ans2');
+					});
+
+					it('should change the selection when selecting an unselected item', function() {
+						// Arrange - item 1 is selected
+						myRadioGroup.selectItemAtIndex(1);
+						var prevSelectEventCount = selectEventCount;
+						lastSelectEventDetails = null;
+						// Act - change the selection to item 2
+						myRadioGroup.selectItemAtIndex(2);
+						// Assert - select event was published
+						expect(selectEventCount, "select event count").is.equal(prevSelectEventCount + 1);
+						expect(lastSelectEventDetails.selectKey).is.equal('ans3');
 					});
 
 					it('should do nothing when selecting an already selected item (no event)', function() {
@@ -208,6 +223,35 @@
 						// Assert - select event was not published
 						expect(selectEventCount, "select event count").is.equal(prevSelectEventCount);
 						expect(lastSelectEventDetails).to.be.null;
+					});
+
+					it.skip('MANUAL TEST: should publish selectedEventId when selection is made w/ mouse or keyboard', function() {
+					});
+				});
+
+				describe('.selectedItem()', function () {
+					before(function () {
+						cntrNode && cntrNode.remove();
+						cntrNode = helper.createNewDiv();
+						myRadioGroup.draw(d3.select(cntrNode));
+					});
+
+					it('should return null when no item is selected', function () {
+						expect(myRadioGroup.selectedItem()).to.be.null;
+					});
+
+					it('should return the selected choice, even after the choice has been changed', function () {
+						// 1st selection
+						myRadioGroup.selectItemAtIndex(1);
+						expect(myRadioGroup.selectedItem()).is.deep.equal(myRadioGroup.choices[1]);
+
+						// 2nd selection is after the current selection
+						myRadioGroup.selectItemAtIndex(3);
+						expect(myRadioGroup.selectedItem()).is.deep.equal(myRadioGroup.choices[3]);
+
+						// 3rd selection is before the current selection
+						myRadioGroup.selectItemAtIndex(0);
+						expect(myRadioGroup.selectedItem()).is.deep.equal(myRadioGroup.choices[0]);
 					});
 				});
 			});	


### PR DESCRIPTION
`RadioGroup` now has reasonably complete functionality.
I added methods `.selectedItem()` and `.selectItemAtIndex()` along w/ unit tests, and I have the widget correctly publishing the `.selectedEventId` when the selection changes programmatically and by the user clicking.

The next step is to create a `SelectOneQuestion` widget which utilizes this RadioButton widget.
