### PR TITLE
fix sliders on Kantorowski

### DIFF
--- a/KantorowskiRotation.html
+++ b/KantorowskiRotation.html
@@ -257,10 +257,10 @@
 
 	// Handle changes of the levo and dextro input values
 	eventManager.subscribe(inputLevo.changedValueEventId,
-						   function(ed) { handleInputValueChanged(inputDextro, ed.value); });
+						   function(ed) { handleInputValueChanged(inputDextro, ed.newValue); });
 	eventManager.subscribe(inputDextro.changedValueEventId,
-						   function(ed) { handleInputValueChanged(inputLevo, ed.value); });
-	eventManager.subscribe(sl1.changedValueEventId, function(ed) { handleNumericInputChanged(ed.value); });
+						   function(ed) { handleInputValueChanged(inputLevo, ed.newValue); });
+	eventManager.subscribe(sl1.changedValueEventId, function(ed) { handleNumericInputChanged(ed.newValue); });
 	
 
 	/* **************************************************************************

--- a/js/widget-slider.js
+++ b/js/widget-slider.js
@@ -16,7 +16,7 @@
  *
  * **************************************************************************/
 
-// Sample BarChart constructor configuration
+// Sample Slider constructor configuration
 (function()
 {
 	var sl1Config = {
@@ -142,8 +142,8 @@ Slider.prototype.draw = function(container)
 	var readOut = $("<span class='readout'>" + this.format(this.startVal) + "</span>");
 
 	// All widgets get a top level "grouping" element which gets a class identifying the widget type.
-	$(cntrElement).append($("<span />").addClass("widgetSlider"));
-	var widgetGroup = $("span.widgetSlider", cntrElement);
+	var widgetGroup = $("<span />").addClass("widgetSlider");
+	$(cntrElement).append(widgetGroup);
 
 	//write a label in front of the input if there is one
 	widgetGroup


### PR DESCRIPTION
- Kantorowski sliders needed to use new eventDetails property (newValue instead of value)
- Slider needed to handle being drawn into a container that already had a slider in it.

@lbondaryk So it turns out that the Kantorowski page is drawing both sliders into the same span as a container (it wasn't supposed to it's a typo which I didn't fix). That turned out to be a good test, catching a bug I had created in the slider.
