### PR TITLE
547 slider bric

### DIFF
--- a/EnergyParabola.html
+++ b/EnergyParabola.html
@@ -187,7 +187,8 @@ var cntr = new SVGContainer(cntrConfig);
 			stepVal: .1,
 			unit: "m/s",
 			label: "Initial Velocity",
-			format: '.1f'
+			format: '.1f',
+			width: '43%'
 		}, eventManager);
 		
 	velocity.draw(d3.select("#veloSlider"));
@@ -202,7 +203,8 @@ var cntr = new SVGContainer(cntrConfig);
 			stepVal: 1,
 			unit: "&deg;",
 			label: "Angle of velocity &theta;",
-			format: '.1f'
+			format: '.1f',
+			width: '43%'
 		}, eventManager);
 		
 	angle.draw(d3.select("#angleSlider"));

--- a/css/widgets.css
+++ b/css/widgets.css
@@ -191,6 +191,7 @@ svg g.brixLabel.lit .descLabel
 {
   margin-left: .5em;
   background-color: #fff;
+  font-weight: bold;
 }
 
 .bricSlider-widget {

--- a/css/widgets.css
+++ b/css/widgets.css
@@ -171,22 +171,47 @@ svg g.brixLabel.lit .descLabel
 /* Sliders
 ================================================== */
 
-span.widgetSlider 
-{
-  font-size: 14px;
-  margin-left: 3px;  
-  margin-right: 10px; 
-  margin-bottom: 40px;
-  padding-top: 10px;
-  padding-left: 10px;
-  border: 1px solid #e4e4e4;
-  max-width: 30px;
+.bricSlider {
+  /*background-color: ThreeDFace;*/
+  position: relative;
+  overflow: hidden;
+}
+.bricSlider-thumb {
+  position: absolute;
+  background-color: ThreeDShadow;
+  overflow: hidden;
 }
 
-span.widgetSlider .range
-{
-  margin-left: 10px;
-  margin-right: 10px;
+.goog-slider-vertical .bricSlider-thumb {
+  left: 0;
+  height: 20px;
+  width: 100%;
+}
+
+.goog-slider-horizontal .bricSlider-thumb {
+    top: 0;
+    width: 15px;
+    height: 80%;
+    background-color: #dae3f1;
+    border: 1px solid #c8d5ea;
+    border-radius:5px;
+    /*box-shadow: 2px 2px 2px #888888;*/
+}
+
+.bricSlider-rail {
+    border: 1px solid #aaaaaa;
+    height: .8em;
+    margin-top: 3px;
+}
+
+.bric-round-corner {
+    border-bottom-right-radius: 4px;
+    border-bottom-left-radius: 4px;
+    border-top-right-radius: 4px;
+    border-top-left-radius: 4px;
+}
+.goog-slider-disabled {
+    background-color: lightgray
 }
 
 /* Radio groups

--- a/css/widgets.css
+++ b/css/widgets.css
@@ -171,11 +171,33 @@ svg g.brixLabel.lit .descLabel
 /* Sliders
 ================================================== */
 
-.bricSlider {
+.bric-round-corner {
+    border-bottom-right-radius: 5px;
+    border-bottom-left-radius: 5px;
+    border-top-right-radius: 5px;
+    border-top-left-radius: 5px;
+}
+
+.bricSlider-container
+{
+  margin: 2px;
+  padding: 8px;
+  background-color: #F8F8F8;
+  border-radius: 8px;
+  display: inline-block;
+}
+
+.bricSlider-container .readout
+{
+  margin-left: .5em;
+  background-color: #fff;
+}
+
+.bricSlider-widget {
   /*background-color: ThreeDFace;*/
-  position: relative;
   overflow: hidden;
 }
+
 .bricSlider-thumb {
   position: absolute;
   background-color: ThreeDShadow;
@@ -190,26 +212,21 @@ svg g.brixLabel.lit .descLabel
 
 .goog-slider-horizontal .bricSlider-thumb {
     top: 0;
-    width: 15px;
-    height: 80%;
-    background-color: #dae3f1;
-    border: 1px solid #c8d5ea;
-    border-radius:5px;
+    width: 8px;
+    height: 8px;
+    background-color: #fff;
+    border: 6px solid black;
+    border-radius:15px;
     /*box-shadow: 2px 2px 2px #888888;*/
 }
 
 .bricSlider-rail {
     border: 1px solid #aaaaaa;
-    height: .8em;
-    margin-top: 3px;
+    height: .7em;
+    margin-top: 4px;
+    background-color: #d0d0d0;
 }
 
-.bric-round-corner {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
-}
 .goog-slider-disabled {
     background-color: lightgray
 }

--- a/css/widgets.css
+++ b/css/widgets.css
@@ -182,7 +182,7 @@ svg g.brixLabel.lit .descLabel
 {
   margin: 2px;
   padding: 8px;
-  background-color: #F8F8F8;
+  background-color: #fff;
   border-radius: 8px;
   display: inline-block;
 }
@@ -213,18 +213,19 @@ svg g.brixLabel.lit .descLabel
 
 .goog-slider-horizontal .bricSlider-thumb {
     top: 0;
-    width: 8px;
-    height: 8px;
-    background-color: #fff;
-    border: 6px solid black;
+    width: 18px;
+    height: 18px;
+    background-color: #444;
+    border: 1px solid black;
     border-radius:15px;
     /*box-shadow: 2px 2px 2px #888888;*/
 }
 
 .bricSlider-rail {
-    border: 1px solid #aaaaaa;
+    border: 1px solid #cccccc;
     height: .7em;
-    margin-top: 4px;
+    margin-top: 5px;
+    margin-bottom: 5px;
     background-color: #d0d0d0;
 }
 

--- a/css/widgets.css
+++ b/css/widgets.css
@@ -182,21 +182,23 @@ svg g.brixLabel.lit .descLabel
 {
   margin: 2px;
   padding: 8px;
-  background-color: #fff;
+  /*background-color: #fff;*/
   border-radius: 8px;
   display: inline-block;
+  font: 16px Helvetica;
 }
 
 .bricSlider-container .readout
 {
-  margin-left: .5em;
-  background-color: #fff;
+  margin-left: 10px;
   font-weight: bold;
 }
 
 .bricSlider-widget {
   /*background-color: ThreeDFace;*/
   overflow: hidden;
+  margin-top: 18px;
+  margin-bottom: 10px;
 }
 
 .bricSlider-thumb {
@@ -212,21 +214,21 @@ svg g.brixLabel.lit .descLabel
 }
 
 .goog-slider-horizontal .bricSlider-thumb {
-    top: 0;
-    width: 18px;
-    height: 18px;
-    background-color: #444;
-    border: 1px solid black;
+    top: 0px;
+    width: 20px;
+    height: 20px;
+    background-color: #3C434D;
+    border: 0px solid black;
     border-radius:15px;
     /*box-shadow: 2px 2px 2px #888888;*/
 }
 
 .bricSlider-rail {
-    border: 1px solid #cccccc;
-    height: .7em;
+    border: 0px solid #cccccc;
+    height: 10px;
     margin-top: 5px;
     margin-bottom: 5px;
-    background-color: #d0d0d0;
+    background-color: #e4e4e4;
 }
 
 .goog-slider-disabled {

--- a/js/ipc.js
+++ b/js/ipc.js
@@ -64,6 +64,13 @@ goog.require("pearson.brix.BrixLayer");
  ****************************************************************************/
 pearson.brix.Ipc = function (config, eventManager)
 {
+    /**
+     * A logger to help debugging 
+     * @type {goog.debug.Logger}
+     * @private
+     */
+    this.logger_ = goog.debug.Logger.getLogger('pearson.brix.Ipc');
+
     if (!config.ipsBaseUrl)
     {
         throw new Error('IPS server URL not provided.');
@@ -74,13 +81,6 @@ pearson.brix.Ipc = function (config, eventManager)
      * @type {!pearson.utils.IEventManager}
      */
     this.eventManager = eventManager;
-
-    /**
-     * A logger to help debugging 
-     * @type {goog.debug.Logger}
-     * @private
-     */
-    this.logger_ = goog.debug.Logger.getLogger('pearson.brix.Ipc');
 
     /**
      * The IpsProxy used by this Ipc to communicate w/ the IPS

--- a/js/widget-slider.js
+++ b/js/widget-slider.js
@@ -111,7 +111,7 @@ pearson.brix.Slider = function (config, eventManager)
      * @type {string}
      */
 
-    this.unit = config.unit;
+    this.unit = config.unit || '';
 
     /**
      * Text to display before the readout and slider.  Currently for display only.
@@ -130,7 +130,7 @@ pearson.brix.Slider = function (config, eventManager)
      * The width of the Slider in pixel
      * @type {number}
      */
-    this.width = config.width || "200";
+    this.width = config.width || '200';
 
     /**
      * The event manager to use to publish (and subscribe to) events for this widget
@@ -224,7 +224,7 @@ pearson.brix.Slider.prototype.draw = function (container)
         .html(this.label ? this.label : "");
     var readOut = (this.format) ? widgetHeaderDiv.append('span')
             .attr("class", "readout")
-            .html(this.format(this.startVal))
+            .html(this.getFormattedValue(this.startVal))
         : null;
 
     var googSliderDiv = widgetGroup.append("div")
@@ -242,10 +242,10 @@ pearson.brix.Slider.prototype.draw = function (container)
     trackDiv.append('div')
         .attr('class', 'range')
         .attr('style', 'float:right')
-        .html(this.maxVal);
+        .html(this.maxVal.toString() + '&nbsp;' + this.unit);
     trackDiv.append('div')
         .attr('class', 'range')
-        .html(this.minVal);
+        .html(this.minVal.toString() + this.unit);
 
     var sliderEl = googSliderDiv.node();
 
@@ -270,16 +270,17 @@ pearson.brix.Slider.prototype.draw = function (container)
         // passing along the updated value in the numeric field.
         var newVal = googSlider.getValue();
 
-        if (readOut)
-        {
-            readOut.text(that.format(newVal));
-        }
         // we want to publish the changedValue event after the value has been changed
         var oldVal = that.lastdrawn.value;
         that.lastdrawn.value = newVal;
-        that.logger_.finer('Publishing to ' + that.changedValueEventId);
-        that.eventManager.publish(that.changedValueEventId,
-                        {oldValue: oldVal, newValue: newVal});
+
+        if (readOut)
+        {
+            readOut.html(that.getFormattedValue());
+        }
+        var eventDetail = {oldValue: oldVal, newValue: newVal};
+        that.logger_.finer('Publishing to "' + that.changedValueEventId + '"" ' + JSON.stringify(eventDetail));
+        that.eventManager.publish(that.changedValueEventId, eventDetail);
     });
 
     googSlider.listen(goog.ui.SliderBase.EventType.DRAG_START, function() {
@@ -363,4 +364,10 @@ pearson.brix.Slider.prototype.setValue = function (newValue)
     this.lastdrawn.sliderObj.setValue(newValue);
 
     return oldValue;
+};
+
+pearson.brix.Slider.prototype.getFormattedValue = function (value)
+{
+    var valueToFormat = (value !== undefined) ? value : this.lastdrawn.value;
+    return this.format(valueToFormat) + this.unit;
 };

--- a/js/widget-slider.js
+++ b/js/widget-slider.js
@@ -19,6 +19,7 @@
 
 goog.provide('pearson.brix.Slider');
 
+goog.require('goog.debug.Logger');
 goog.require('goog.dom');
 goog.require('goog.ui.Component');
 goog.require('goog.ui.Slider');
@@ -84,6 +85,13 @@ pearson.brix.Slider = function (config, eventManager)
 {
     // call the base class constructor
     goog.base(this);
+
+    /**
+     * A logger to help debugging 
+     * @type {goog.debug.Logger}
+     * @private
+     */
+    this.logger_ = goog.debug.Logger.getLogger('pearson.brix.Slider');
 
     /**
      * A unique id for this instance of the slider widget
@@ -170,6 +178,8 @@ pearson.brix.Slider = function (config, eventManager)
             /** @type {d3.selection} */     readOut: null,
             /** @type {goog.ui.Slider} */   sliderObj: null,
         };
+
+    this.logger_.config('Slider with id:' + this.id + ' created.');
 }; // end of slider constructor
 goog.inherits(pearson.brix.Slider, pearson.brix.HtmlBric);
 
@@ -205,22 +215,21 @@ pearson.brix.Slider.prototype.draw = function (container)
 
     // All widgets get a top level "grouping" element which gets a class identifying the widget type.
     var widgetGroup = container.append("div")
-        .attr("class", "widgetSlider")
+        .attr("class", "bricSlider-container")
         .attr("id", this.id);
-    widgetGroup.append('span')
+    var widgetHeaderDiv = widgetGroup.append('div')
+        .attr("class", "header");
+    widgetHeaderDiv.append('span')
         .attr('role', 'label')
         .html(this.label ? this.label : "");
-    var readOut = (this.format) ? widgetGroup.append('span')
+    var readOut = (this.format) ? widgetHeaderDiv.append('span')
             .attr("class", "readout")
             .html(this.format(this.startVal))
         : null;
-    widgetGroup.append('span')
-        .attr('class', 'range')
-        .html(" &nbsp;&nbsp;&nbsp;" + this.minVal);
 
     var googSliderDiv = widgetGroup.append("div")
-        .attr("class", "bricSlider goog-slider")
-        .attr("style", "display:inline-block; width: " + this.width + "px; height: 20px;");
+        .attr("class", "bricSlider-widget goog-slider")
+        .attr("style", "position:relative; display:inline-block; width: " + this.width + "px; height: 20px;");
     googSliderDiv.append('div') // rail (optional)
         .attr('class', 'bricSlider-rail bric-round-corner');
         // Below is sample from google site
@@ -228,9 +237,15 @@ pearson.brix.Slider.prototype.draw = function (container)
     var thumbDiv = googSliderDiv.append('div')
         .attr('class', 'bricSlider-thumb goog-slider-thumb bric-round-corner');
 
-    widgetGroup.append('span')
+    var trackDiv = widgetGroup.append("div")
+        .attr("class", "track");
+    trackDiv.append('div')
         .attr('class', 'range')
-        .html(" &nbsp;&nbsp;&nbsp;" + this.maxVal);
+        .attr('style', 'float:right')
+        .html(this.maxVal);
+    trackDiv.append('div')
+        .attr('class', 'range')
+        .html(this.minVal);
 
     var sliderEl = googSliderDiv.node();
 
@@ -251,11 +266,10 @@ pearson.brix.Slider.prototype.draw = function (container)
     googSlider.setMoveToPointEnabled(true); // Allows to go to specific point when tapped over the rail
 
     googSlider.listen(goog.ui.Component.EventType.CHANGE, function() {
-        //this publishes the onChange event to the eventManager
-        //passing along the updated value in the numeric field.
+        // This publishes the CHANGE event to the eventManager
+        // passing along the updated value in the numeric field.
         var newVal = googSlider.getValue();
-        //newVal = that.format(newVal);
-        //that.display.setValue(newVal);
+
         if (readOut)
         {
             readOut.text(that.format(newVal));
@@ -263,22 +277,49 @@ pearson.brix.Slider.prototype.draw = function (container)
         // we want to publish the changedValue event after the value has been changed
         var oldVal = that.lastdrawn.value;
         that.lastdrawn.value = newVal;
+        that.logger_.finer('Publishing to ' + that.changedValueEventId);
         that.eventManager.publish(that.changedValueEventId,
                         {oldValue: oldVal, newValue: newVal});
     });
 
     googSlider.listen(goog.ui.SliderBase.EventType.DRAG_START, function() {
+        that.logger_.fine('Publishing to ' + that.dragStartEventId);
         that.eventManager.publish(that.dragStartEventId,
             {value: googSlider.getValue()});
     });
     
     googSlider.listen(goog.ui.SliderBase.EventType.DRAG_END, function() {
+        that.logger_.fine('Publishing to ' + that.dragEndEventId);
         that.eventManager.publish(that.dragEndEventId,
             {value: googSlider.getValue()});
     });
     this.lastdrawn.sliderObj = googSlider;
 
 }; // end of Slider.draw()
+
+/* **************************************************************************
+ * Button.setEnabled                                                   */ /**
+ *
+ * This method sets the current enable state of the button.
+ * @export
+ *
+ * @param {boolean} newEnableState  -true to enable the button, false to disable it.
+ *
+ **************************************************************************/
+pearson.brix.Slider.prototype.setEnabled = function (newEnableState)
+{
+    if (!this.lastdrawn.sliderObj)
+    {
+        // If not drawn yet, nothing to do
+        return;
+    }
+    var stateChanged = this.lastdrawn.sliderObj.isEnabled() !== newEnableState;
+
+    if (stateChanged && this.lastdrawn.widgetGroup)
+    {
+        this.lastdrawn.sliderObj.setEnabled(newEnableState);
+    }
+};
 
 /* **************************************************************************
  * Slider.getValue                                                     */ /**
@@ -315,15 +356,10 @@ pearson.brix.Slider.prototype.setValue = function (newValue)
 {
     var oldValue = this.lastdrawn.value;
 
-    if (newValue === oldValue)
-        return oldValue;
-
+    /*
     // The addEventListener(CHANGE) is called when sliderObj.setValue is called below
     // There is no need to set the readout again.
-    //var jReadout = $("span.readout", this.lastdrawn.widgetGroup);
-    //jReadout.text(this.format(newValue));
-
-    this.lastdrawn.value = newValue;
+    */
     this.lastdrawn.sliderObj.setValue(newValue);
 
     return oldValue;

--- a/js/widget-slider.js
+++ b/js/widget-slider.js
@@ -10,7 +10,6 @@
  * Created on       April 15, 2013
  * @author          Leslie Bondaryk
  * @author          Michael Jay Lippert
- * @author          Greg Davis
  * @author          Young-Suk Ahn
  *
  * @copyright (c) 2013 Pearson, All rights reserved.
@@ -425,11 +424,11 @@ pearson.brix.Slider.prototype.getFormattedValue = function (unitOpt, value)
 
     if (unitOpt == pearson.brix.UnitOpt.APPEND)
     {
-        return this.format(valueToFormat) + this.unit;
+        return this.format(valueToFormat) + (this.unit !== '&deg;' ? '\u2007' : '') + this.unit;
     }
     else if (unitOpt == pearson.brix.UnitOpt.PREPEND)
     {
-        return this.unit + this.format(valueToFormat);
+        return this.unit  + this.format(valueToFormat);
     }
     return this.format(valueToFormat);
 };

--- a/sliderTests.html
+++ b/sliderTests.html
@@ -20,6 +20,11 @@
 
     <!-- content_styles.css contains styling for the narrative layout and responsive design -->
     <link href="css/content_styles.css" rel="stylesheet" media="screen">
+    <style>
+    .test{
+        margin-top: 10px;
+    }
+    </style>
 </head>
 <body>
     <div class="container">
@@ -85,34 +90,27 @@
                 
                 <div class="test">
                     <p>Test 7: Two half-sized sliders</p>
-                    <div class="span6">
+                    <div id="t7sliders">
                         <span id="t7_1slider"></span>
-                    </div>
-                    <div class="span6">
                         <span id="t7_2slider"></span>
                     </div>  
                 </div>
-                
                 
             </div>
             <div class="lc_ec_trailing">
                 
                 <div class="test">
                     <p>Test 8: Slider next to readout</p>
-                    <div class="span3">
+                    <div >
                         Slider value = <span id="t8val"></span>
-                    </div>
-                    <div class="span6">
                         <span id="t8slider"></span>
                     </div>
                 </div>
                 
                 <div class="test">
                     <p>Test 9: Two sliders next to each other</p>
-                    <div class="span6">
+                    <div id="t9sliders">
                         <span id="t9_1slider"></span>
-                    </div>
-                    <div class="span5">
                         <span id="t9_2slider"></span>
                     </div>
                 </div>
@@ -215,6 +213,7 @@
             stepVal: .01,
             label: "Test 0 slider",
             format: '5.2f',
+            unit: '&deg;'
         }, eventManager);
     
     t0Slide.draw(d3.select("#t0slider"));
@@ -243,7 +242,6 @@
             maxVal: t1_2Extent[1],
             stepVal: .01,
             label: "Test 1 slider 2",
-            format: '5.2f',
         }, eventManager);
         
     t1_2Slide.draw(d3.select("#t1_2slider"));
@@ -261,6 +259,7 @@
             stepVal: .01,
             label: "Test 2 slider",
             format: '5.2f',
+            unit: 'µ',
         }, eventManager);
         
     t2Slide.draw(d3.select("#t2slider"));
@@ -495,7 +494,8 @@
             minVal: t7_1Extent[0],
             maxVal: t7_1Extent[1],
             stepVal: 1,
-            label: "Test 7 slider 1",
+            width: 100,
+            label: "Test7 sldr 1",
             format: '5.2f',
         }, eventManager);
         
@@ -507,7 +507,8 @@
             minVal: t7_2Extent[0],
             maxVal: t7_2Extent[1],
             stepVal: 1,
-            label: "Test 7 slider 2",
+            width: 100,
+            label: "Test7 sldr 2",
             format: '5.2f',
         }, eventManager);
         
@@ -554,15 +555,15 @@
     ////////////////////////////////////////////////
     
     // Test 9: Two sliders next to each other
-    var t9_1Extent = [0, 10],
-        t9_2Extent = [0, 10];
+    var t9_1Extent = [0, 100000],
+        t9_2Extent = [0.1, 0.2];
         
     var t9_1Slide = new Slider ({
             id: "t9_1Val",
-            startVal: 1,
+            startVal: t9_1Extent[0],
             minVal: t9_1Extent[0],
             maxVal: t9_1Extent[1],
-            stepVal: 1,
+            stepVal: 100,
             label: "Test 9 slider 1",
             format: '5.2f',
         }, eventManager);
@@ -571,10 +572,9 @@
     
     var t9_2Slide = new Slider ({
             id: "t9_2Val",
-            startVal: 1,
+            startVal: t9_2Extent[0],
             minVal: t9_2Extent[0],
             maxVal: t9_2Extent[1],
-            stepVal: 1,
             label: "Test 9 slider 2",
             format: '5.2f',
         }, eventManager);
@@ -595,6 +595,7 @@
             stepVal: .1,
             label: "Test 10 slider 1",
             format: '5.2f',
+            unit: 'Å'
         }, eventManager);
         
     t10_1Slide.draw(d3.select("#t10_1slider"));
@@ -604,7 +605,7 @@
             id: "t10_1Read",
             startVal: test10function(t10_1Slide.getValue()),
             readOnly: true,
-            size: 10
+            size: 10,
         }, eventManager);
     
     var t10_2Slide = new Slider ({
@@ -615,6 +616,7 @@
             stepVal: .1,
             label: "Test 10 slider 2",
             format: '5.2f',
+            unit: 'Å'
         }, eventManager);
         
     t10_2Slide.draw(d3.select("#t10_2slider"));

--- a/sliderTests.html
+++ b/sliderTests.html
@@ -1,166 +1,167 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta charset="UTF-8">
-	<meta name="Author" content="Leslie Bondaryk" />
-	<meta name="Owner" content="Pearson" />
-	<meta name="Copyright" content="Copyright (c) 2013 Pearson. All rights reserved." />
-	<meta content="width=device-width, initial-scale=1.0" name="viewport" />
-	<meta content="Carmen Santiago, Demo Book" name="description" />
-	<title class="setTitle"></title>
+    <meta charset="UTF-8">
+    <meta name="Author" content="Leslie Bondaryk" />
+    <meta name="Owner" content="Pearson" />
+    <meta name="Copyright" content="Copyright (c) 2013 Pearson. All rights reserved." />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <meta content="Carmen Santiago, Demo Book" name="description" />
+    <title class="setTitle"></title>
 
     <!-- bootstrap_plus.css contains styling for the dropdown menu and other common core styles -->
     <link href="css/bootstrap_plus.css" rel="stylesheet" media="screen">
-  	
-  	<!-- widgets.css contains styling for the interactive brix -->
-	<link href="css/widgets.css" rel="stylesheet">
+    
+    <!-- widgets.css contains styling for the interactive brix -->
+    <link href="css/widgets.css" rel="stylesheet">
 
-	<!-- eCourse-master.css contains styling for all the navigation -->
-	<link href="css/eCourse-master.css" rel="stylesheet" media="screen">
+    <!-- eCourse-master.css contains styling for all the navigation -->
+    <link href="css/eCourse-master.css" rel="stylesheet" media="screen">
 
-	<!-- content_styles.css contains styling for the narrative layout and responsive design -->
-	<link href="css/content_styles.css" rel="stylesheet" media="screen">
+    <!-- content_styles.css contains styling for the narrative layout and responsive design -->
+    <link href="css/content_styles.css" rel="stylesheet" media="screen">
 </head>
 <body>
-	<div class="container">
-		<div class="span12 lc_ec_page">
-			<section class="lc_ec_fiftyFifty lc_ec_pageInner">
-       	 		<div class="lc_ec_content">
-       	 			<h2 class="lc_ec_bHead"><span class='number setId'></span> 
-											<span class="setTitle"></span>
-					</h2>
-		 			<div class="lc_ec_leading">
-				<div class="test">
-					<p>Test 0: One slider, no readout</p>
-					<span id="t0slider"></span>
-				</div>
-				
-				<div class="test">
-					<p>Test 1: Two sliders, no readout</p>
-					<div id="t1sliders">
-						<span id="t1_1slider"></span>
-						<span id="t1_2slider"></span>
-					</div>
-				</div>
-				
-				<div class="test">
-					<p>Test 2: One slider, one readout</p>
-					<span id="t2slider"></span>
-					<p>Test 2 slider value = <span id="t2val"></span></p>
-				</div>
-				
-				<div class="test">
-					<p>Test 3: Two sliders, one readout</p>
-					<div id="t3sliders">
-						<span id="t3_1slider"></span>
-						<span id="t3_2slider"></span>
-					</div>
-					<p>Slider 1 + Slider 2 = <span id="t3val"></span></p>
-				</div>
-				
-				<div class="test">
-					<p>Test 4: Two sliders, two readouts</p>
-					<div id="t4sliders">
-						<span id="t4_1slider"></span>
-						<span id="t4_2slider"></span>
-					</div>
-					<p>Slider 1 = <span id="t4_1val"></span></p>
-					<p>Slider 2 = <span id="t4_2val"></span></p>
-				</div>
-				
-				<div class="test">
-					<p>Test 5: Three sliders, one readout</p>
-					<div id="t5sliders">
-						<span id="t5_1slider"></span><br />
-						<span id="t5_2slider"></span><br />
-						<span id="t5_3slider"></span>
-					</div>
-					<p>(Slider 1 + Slider 2) / Slider 3 = <span id="t5val"></span></p>
-				</div>
-				
-				<div class="test">
-					<p>Test 6: One readout, no slider</p>
-					<p>Readout value = <span id="t6val"></span></p>
-				</div>
-				
-				<div class="test">
-					<p>Test 7: Two half-sized sliders</p>
-					<div class="span6">
-						<span id="t7_1slider"></span>
-					</div>
-					<div class="span6">
-						<span id="t7_2slider"></span>
-					</div>	
-				</div>
-				
-				
-			</div>
-			<div class="lc_ec_trailing">
-				
-				<div class="test">
-					<p>Test 8: Slider next to readout</p>
-					<div class="span3">
-						Slider value = <span id="t8val"></span>
-					</div>
-					<div class="span6">
-						<span id="t8slider"></span>
-					</div>
-				</div>
-				
-				<div class="test">
-					<p>Test 9: Two sliders next to each other</p>
-					<div class="span6">
-						<span id="t9_1slider"></span>
-					</div>
-					<div class="span5">
-						<span id="t9_2slider"></span>
-					</div>
-				</div>
-				
-				<div class="text">
-					<p>Test 10: One slider changing another</p>
-					<div id="t10sliders">
-						<span id="t10_1slider"></span>
-						<span id="t10_2slider"></span>
-					</div>
-					<p><span id="t10_1val"></span> + <span id="t10_2val"></span> = 100</p>
-				</div>
-				
-			</div>
-		</div>
-	</section>
+    <div class="container">
+        <div class="span12 lc_ec_page">
+            <section class="lc_ec_fiftyFifty lc_ec_pageInner">
+                <div class="lc_ec_content">
+                    <h2 class="lc_ec_bHead"><span class='number setId'></span> 
+                                            <span class="setTitle"></span>
+                    </h2>
+                    <div class="lc_ec_leading">
+                <div class="test">
+                    <p>Test 0: One slider, no readout</p>
+                    <span id="t0slider"></span>
+                </div>
+                
+                <div class="test">
+                    <p>Test 1: Two sliders, no readout</p>
+                    <div id="t1sliders">
+                        <span id="t1_1slider"></span>
+                        <span id="t1_2slider"></span>
+                    </div>
+                </div>
+                
+                <div class="test">
+                    <p>Test 2: One slider, one readout</p>
+                    <span id="t2slider"></span>
+                    <p>Test 2 slider value = <span id="t2val"></span></p>
+                </div>
+                
+                <div class="test">
+                    <p>Test 3: Two sliders, one readout</p>
+                    <div id="t3sliders">
+                        <span id="t3_1slider"></span>
+                        <span id="t3_2slider"></span>
+                    </div>
+                    <p>Slider 1 + Slider 2 = <span id="t3val"></span></p>
+                </div>
+                
+                <div class="test">
+                    <p>Test 4: Two sliders, two readouts</p>
+                    <div id="t4sliders">
+                        <span id="t4_1slider"></span>
+                        <span id="t4_2slider"></span>
+                    </div>
+                    <p>Slider 1 = <span id="t4_1val"></span></p>
+                    <p>Slider 2 = <span id="t4_2val"></span></p>
+                </div>
+                
+                <div class="test">
+                    <p>Test 5: Three sliders, one readout</p>
+                    <div id="t5sliders">
+                        <span id="t5_1slider"></span><br />
+                        <span id="t5_2slider"></span><br />
+                        <span id="t5_3slider"></span>
+                    </div>
+                    <p>(Slider 1 + Slider 2) / Slider 3 = <span id="t5val"></span></p>
+                </div>
+                
+                <div class="test">
+                    <p>Test 6: One readout, no slider</p>
+                    <p>Readout value = <span id="t6val"></span></p>
+                </div>
+                
+                <div class="test">
+                    <p>Test 7: Two half-sized sliders</p>
+                    <div class="span6">
+                        <span id="t7_1slider"></span>
+                    </div>
+                    <div class="span6">
+                        <span id="t7_2slider"></span>
+                    </div>  
+                </div>
+                
+                
+            </div>
+            <div class="lc_ec_trailing">
+                
+                <div class="test">
+                    <p>Test 8: Slider next to readout</p>
+                    <div class="span3">
+                        Slider value = <span id="t8val"></span>
+                    </div>
+                    <div class="span6">
+                        <span id="t8slider"></span>
+                    </div>
+                </div>
+                
+                <div class="test">
+                    <p>Test 9: Two sliders next to each other</p>
+                    <div class="span6">
+                        <span id="t9_1slider"></span>
+                    </div>
+                    <div class="span5">
+                        <span id="t9_2slider"></span>
+                    </div>
+                </div>
+                
+                <div class="text">
+                    <p>Test 10: One slider changing another</p>
+                    <div id="t10sliders">
+                        <span id="t10_1slider"></span>
+                        <span id="t10_2slider"></span>
+                    </div>
+                    <p><span id="t10_1val"></span> + <span id="t10_2val"></span> = 100</p>
+                </div>
+                
+            </div>
+        </div>
+    </section>
     </div>
 </div>
 
     <script src="js/jquery-latest.js"></script>
     <script src="js/bootstrap.min.js"></script>
-	<!--script src="js/jquery.touchSwipe.min.js"></script-->
-	<script src="js/jquery-ui-1.10.2.custom.js"></script>
+    <!--script src="js/jquery.touchSwipe.min.js"></script-->
+    <script src="js/jquery-ui-1.10.2.custom.js"></script>
     <script src="js/toc-structure.js"></script>    
     <script src="js/eCourse-master.js"></script>    
     <script src="js/d3.v3.min.js"></script>
 
-	<script src="js/brixlib-compiled.js"></script>
-	<!--
-	<script src="../closure/closure-library/closure/goog/base.js"></script>
-	<script src="../closure/closure-library/closure/goog/deps.js"></script>
+    <!--<script src="js/brixlib-compiled.js"></script>-->
+    
+    <script src="../closure/closure-library/closure/goog/base.js"></script>
+    <script src="../closure/closure-library/closure/goog/deps.js"></script>
 
-	<script src="js/eventmanager.js"></script>
-	<script src="js/fakeactivitydb.js"></script>
-	<script src="js/answerman.js"></script>
-	<script src="js/submitmanager.js"></script>
-	<script src="js/widget-base.js"></script>
+    <script src="js/eventmanager.js"></script>
+    <script src="js/fakeactivitydb.js"></script>
+    <script src="js/answerman.js"></script>
+    <script src="js/submitmanager.js"></script>
+    <script src="js/widget-base.js"></script>
+    <script src="js/widget-prototype-axes.js"></script>
     <script src="js/widget-numeric.js"></script>
     <script src="js/widget-legend.js"></script>
     <script src="js/widget-callouts.js"></script>
     <script src="js/widget-button.js"></script>
-	<script src="js/widget-linegraph.js"></script>
-	<script src="js/widget-barchart.js"></script>
+    <script src="js/widget-linegraph.js"></script>
+    <script src="js/widget-barchart.js"></script>
     <script src="js/widget-piechart.js"></script>
     <script src="js/widget-image.js"></script>
     <script src="js/widget-carousel.js"></script>
     <script src="js/widget-imageviewer.js"></script>
-	<script src="js/widget-labelgroup.js"></script>
+    <script src="js/widget-labelgroup.js"></script>
     <script src="js/widget-markergroup.js"></script>
     <script src="js/widget-radiogroup.js"></script>
     <script src="js/widget-checkgroup.js"></script>
@@ -168,480 +169,479 @@
     <script src="js/widget-multiplechoicequestion.js"></script>
     <script src="js/widget-numericquestion.js"></script>
     <script src="js/widget-slider.js"></script>
-	-->
+
 
 <script>
-	// local aliases for convenience
-	var EventManager = pearson.utils.EventManager;
-	var Rect = pearson.utils.Rect;
-	var Size = pearson.utils.Size;
-	var SVGContainer = pearson.brix.SVGContainer;
-	var Image = pearson.brix.Image;
-	var CaptionedImage = pearson.brix.CaptionedImage;
-	var Carousel = pearson.brix.Carousel;
-	var ImageViewer = pearson.brix.ImageViewer;
-	var Callouts = pearson.brix.Callouts;
-	var LabelGroup = pearson.brix.LabelGroup;
-	var MarkerGroup = pearson.brix.MarkerGroup;
-	var BarChart = pearson.brix.BarChart;
-	var LineGraph = pearson.brix.LineGraph;
-	var PieChart = pearson.brix.PieChart;
-	var Legend = pearson.brix.Legend;
-	var Sketch = pearson.brix.Sketch;
-	var Readout = pearson.brix.Readout;
-	var NumericInput = pearson.brix.NumericInput;
-	var Slider = pearson.brix.Slider;
+    // local aliases for convenience
+    var EventManager = pearson.utils.EventManager;
+    var Rect = pearson.utils.Rect;
+    var Size = pearson.utils.Size;
+    var SVGContainer = pearson.brix.SVGContainer;
+    var Image = pearson.brix.Image;
+    var CaptionedImage = pearson.brix.CaptionedImage;
+    var Carousel = pearson.brix.Carousel;
+    var ImageViewer = pearson.brix.ImageViewer;
+    var Callouts = pearson.brix.Callouts;
+    var LabelGroup = pearson.brix.LabelGroup;
+    var MarkerGroup = pearson.brix.MarkerGroup;
+    var BarChart = pearson.brix.BarChart;
+    var LineGraph = pearson.brix.LineGraph;
+    var PieChart = pearson.brix.PieChart;
+    var Legend = pearson.brix.Legend;
+    var Sketch = pearson.brix.Sketch;
+    var Readout = pearson.brix.Readout;
+    var NumericInput = pearson.brix.NumericInput;
+    var Slider = pearson.brix.Slider;
 
-	// create event manager
-	var eventManager = new EventManager();
-	
-	////////////////////////////////////////
-	
-	// Test 0: One slider, no readout
-	var t0Extent = [0, 1];
-	
-	var t0Slide = new Slider ({
-			id: "t0Val",
-			startVal: 0.5,
-			minVal: t0Extent[0],
-			maxVal: t0Extent[1],
-			stepVal: .01,
-			label: "Test 0 slider",
-			format: '5.2f',
-		}, eventManager);
-	
-	t0Slide.draw(d3.select("#t0slider"));
-	
-	/////////////////////////////////////////
-	
-	// Test 1: Two sliders, no readout
-	var t1_1Extent = [0, 1],
-		t1_2Extent = [0, 10];
-		
-	var t1_1Slide = new Slider ({
-			id: "t1_1Val",
-			startVal: 0.5,
-			minVal: t1_1Extent[0],
-			maxVal: t1_1Extent[1],
-			stepVal: .01,
-			label: "Test 1 slider 1",
-			format: '5.2f',
-		}, eventManager);
-		
-	t1_1Slide.draw(d3.select("#t1_1slider"));
-		
-	var t1_2Slide = new Slider ({
-			id: "t1_2Val",
-			startVal: 5.0,
-			minVal: t1_2Extent[0],
-			maxVal: t1_2Extent[1],
-			stepVal: .01,
-			label: "Test 1 slider 2",
-			format: '5.2f',
-		}, eventManager);
-		
-	t1_2Slide.draw(d3.select("#t1_2slider"));
-	
-	///////////////////////////////////////////
-	
-	// Test 2: One slider, one readout
-	var t2Extent = [0, 20];
-	
-	var t2Slide = new Slider ({
-			id: "t2Val",
-			startVal: 10.0,
-			minVal: t2Extent[0],
-			maxVal: t2Extent[1],
-			stepVal: .01,
-			label: "Test 2 slider",
-			format: '5.2f',
-		}, eventManager);
-		
-	t2Slide.draw(d3.select("#t2slider"));
-	
-	var t2Readout = new Readout ({
-			node: d3.select("#t2val"),
-			id: "t2Read",
-			startVal: test2function(t2Slide.getValue()),
-			readOnly: true,
-			size: 10,
-		}, eventManager);
-		
-	function test2function(input)
-	{
-		return d3.round(input, 2);
-	}
-	
-	eventManager.subscribe(t2Slide.changedValueEventId, t2handleChangedValue);
-	
-	function t2handleChangedValue(eventDetails)
-	{
-		newVal = test2function(t2Slide.getValue());
-		t2Readout.setValue(newVal);
-	}
-	
-	//////////////////////////////////////////////
-	
-	// Test 3: Two sliders, one readout
-	var t3_1Extent = [0, 5],
-		t3_2Extent = [0, 15];
-		
-	var t3_1Slide = new Slider ({
-			id: "t3_1Val",
-			startVal: 2.5,
-			minVal: t3_1Extent[0],
-			maxVal: t3_1Extent[1],
-			stepVal: .01,
-			label: "Test 3 slider 1",
-			format: '5.2f',
-		}, eventManager);
+    // create event manager
+    var eventManager = new EventManager();
+    
+    ////////////////////////////////////////
+    
+    // Test 0: One slider, no readout
+    var t0Extent = [0, 1];
+    
+    var t0Slide = new Slider ({
+            id: "t0Val",
+            startVal: 0.5,
+            minVal: t0Extent[0],
+            maxVal: t0Extent[1],
+            stepVal: .01,
+            label: "Test 0 slider",
+            format: '5.2f',
+        }, eventManager);
+    
+    t0Slide.draw(d3.select("#t0slider"));
+    
+    /////////////////////////////////////////
+    
+    // Test 1: Two sliders, no readout
+    var t1_1Extent = [0, 1],
+        t1_2Extent = [0, 10];
+        
+    var t1_1Slide = new Slider ({
+            id: "t1_1Val",
+            startVal: 0.5,
+            minVal: t1_1Extent[0],
+            maxVal: t1_1Extent[1],
+            stepVal: .01,
+            label: "Test 1 slider 1",
+        }, eventManager);
+        
+    t1_1Slide.draw(d3.select("#t1_1slider"));
+        
+    var t1_2Slide = new Slider ({
+            id: "t1_2Val",
+            startVal: 5.0,
+            minVal: t1_2Extent[0],
+            maxVal: t1_2Extent[1],
+            stepVal: .01,
+            label: "Test 1 slider 2",
+            format: '5.2f',
+        }, eventManager);
+        
+    t1_2Slide.draw(d3.select("#t1_2slider"));
+    
+    ///////////////////////////////////////////
+    
+    // Test 2: One slider, one readout
+    var t2Extent = [0, 20];
+    
+    var t2Slide = new Slider ({
+            id: "t2Val",
+            startVal: 10.0,
+            minVal: t2Extent[0],
+            maxVal: t2Extent[1],
+            stepVal: .01,
+            label: "Test 2 slider",
+            format: '5.2f',
+        }, eventManager);
+        
+    t2Slide.draw(d3.select("#t2slider"));
+    
+    var t2Readout = new Readout ({
+            node: d3.select("#t2val"),
+            id: "t2Read",
+            startVal: test2function(t2Slide.getValue()),
+            readOnly: true,
+            size: 10,
+        }, eventManager);
+        
+    function test2function(input)
+    {
+        return d3.round(input, 2);
+    }
+    
+    eventManager.subscribe(t2Slide.changedValueEventId, t2handleChangedValue);
+    
+    function t2handleChangedValue(eventDetails)
+    {
+        newVal = test2function(t2Slide.getValue());
+        t2Readout.setValue(newVal);
+    }
+    
+    //////////////////////////////////////////////
+    
+    // Test 3: Two sliders, one readout
+    var t3_1Extent = [0, 5],
+        t3_2Extent = [0, 15];
+        
+    var t3_1Slide = new Slider ({
+            id: "t3_1Val",
+            startVal: 2.5,
+            minVal: t3_1Extent[0],
+            maxVal: t3_1Extent[1],
+            stepVal: .01,
+            label: "Test 3 slider 1",
+            format: '5.2f',
+        }, eventManager);
 
-	t3_1Slide.draw(d3.select("#t3_1slider"));
+    t3_1Slide.draw(d3.select("#t3_1slider"));
 
-	var t3_2Slide = new Slider ({
-			id: "t3_2Val",
-			startVal: 7.5,
-			minVal: t3_2Extent[0],
-			maxVal: t3_2Extent[1],
-			stepVal: .01,
-			label: "Test 3 slider 2",
-			format: '5.2f',
-		}, eventManager);
+    var t3_2Slide = new Slider ({
+            id: "t3_2Val",
+            startVal: 7.5,
+            minVal: t3_2Extent[0],
+            maxVal: t3_2Extent[1],
+            stepVal: .01,
+            label: "Test 3 slider 2",
+            format: '5.2f',
+        }, eventManager);
 
-	t3_2Slide.draw(d3.select("#t3_2slider"));
-	
-	var t3Readout = new Readout ({
-			node: d3.select("#t3val"),
-			id: "t3Read",
-			startVal: test3function(t3_1Slide.getValue(), t3_2Slide.getValue()),
-			readOnly: true,
-			size: 10,
-		}, eventManager);
-		
-	function test3function (input1, input2)
-	{
-		return d3.round((d3.round(input1, 2) + d3.round(input2, 2)), 2);
-	}
-	
-	eventManager.subscribe(t3_1Slide.changedValueEventId, t3handleChangedValue);
-	eventManager.subscribe(t3_2Slide.changedValueEventId, t3handleChangedValue);
-	
-	function t3handleChangedValue(eventDetails)
-	{
-		slide1 = t3_1Slide.getValue();
-		slide2 = t3_2Slide.getValue();
-		/*console.log("eventDetails.newValue=" + eventDetails.newValue +
-					"; slide1=" + slide1 +
-					"; slide2=" + slide2 + ";");*/
-		newVal = test3function(slide1, slide2);
-		t3Readout.setValue(newVal);
-	}
-	
-	////////////////////////////////////////////////
-	
-	// Test 4: Two sliders, two readouts
-	var t4_1Extent = [0, 10],
-		t4_2Extent = [0, 20];
-		
-	var t4_1Slide = new Slider ({
-			id: "t4_1Val",
-			startVal: 5.0,
-			minVal: t4_1Extent[0],
-			maxVal: t4_1Extent[1],
-			stepVal: .01,
-			label: "Test 4 slider 1",
-			format: '5.2f',
-		}, eventManager);
+    t3_2Slide.draw(d3.select("#t3_2slider"));
+    
+    var t3Readout = new Readout ({
+            node: d3.select("#t3val"),
+            id: "t3Read",
+            startVal: test3function(t3_1Slide.getValue(), t3_2Slide.getValue()),
+            readOnly: true,
+            size: 10,
+        }, eventManager);
+        
+    function test3function (input1, input2)
+    {
+        return d3.round((d3.round(input1, 2) + d3.round(input2, 2)), 2);
+    }
+    
+    eventManager.subscribe(t3_1Slide.changedValueEventId, t3handleChangedValue);
+    eventManager.subscribe(t3_2Slide.changedValueEventId, t3handleChangedValue);
+    
+    function t3handleChangedValue(eventDetails)
+    {
+        slide1 = t3_1Slide.getValue();
+        slide2 = t3_2Slide.getValue();
+        /*console.log("eventDetails.newValue=" + eventDetails.newValue +
+                    "; slide1=" + slide1 +
+                    "; slide2=" + slide2 + ";");*/
+        newVal = test3function(slide1, slide2);
+        t3Readout.setValue(newVal);
+    }
+    
+    ////////////////////////////////////////////////
+    
+    // Test 4: Two sliders, two readouts
+    var t4_1Extent = [0, 10],
+        t4_2Extent = [0, 20];
+        
+    var t4_1Slide = new Slider ({
+            id: "t4_1Val",
+            startVal: 5.0,
+            minVal: t4_1Extent[0],
+            maxVal: t4_1Extent[1],
+            stepVal: .01,
+            label: "Test 4 slider 1",
+            format: '5.2f',
+        }, eventManager);
 
-	t4_1Slide.draw(d3.select("#t4_1slider"));
+    t4_1Slide.draw(d3.select("#t4_1slider"));
 
-	var t4_2Slide = new Slider ({
-			id: "t4_2Val",
-			startVal: 10.0,
-			minVal: t4_2Extent[0],
-			maxVal: t4_2Extent[1],
-			stepVal: .01,
-			label: "Test 4 slider 2",
-			format: '5.2f',
-		}, eventManager);
+    var t4_2Slide = new Slider ({
+            id: "t4_2Val",
+            startVal: 10.0,
+            minVal: t4_2Extent[0],
+            maxVal: t4_2Extent[1],
+            stepVal: .01,
+            label: "Test 4 slider 2",
+            format: '5.2f',
+        }, eventManager);
 
-	t4_2Slide.draw(d3.select("#t4_2slider"));
-	
-	var t4_1Readout = new Readout ({
-			node: d3.select("#t4_1val"),
-			id: "t4_1Read",
-			startVal: test4function(t4_1Slide.getValue()),
-			readOnly: true,
-			size: 10,
-		}, eventManager);
-		
-	var t4_2Readout = new Readout ({
-			node: d3.select("#t4_2val"),
-			id: "t4_2Read",
-			startVal: test4function(t4_2Slide.getValue()),
-			readOnly: true,
-			size: 10,
-		}, eventManager);
-		
-	function test4function (input)
-	{
-		return d3.round(input, 2);
-	}
-	
-	eventManager.subscribe(t4_1Slide.changedValueEventId, t4handleChangedValue);
-	eventManager.subscribe(t4_2Slide.changedValueEventId, t4handleChangedValue);
-	
-	function t4handleChangedValue (newValue)
-	{
-		newVal1 = test4function(t4_1Slide.getValue());
-		newVal2 = test4function(t4_2Slide.getValue());
-		
-		t4_1Readout.setValue(newVal1);
-		t4_2Readout.setValue(newVal2);
-	}
-	
-	///////////////////////////////////////////////
-	
-	// Test 5: Three sliders, one readout
-	var t5_1Extent = [0, 10],
-		t5_2Extent = [0, 20],
-		t5_3Extent = [1, 5];
-		
-	var t5_1Slide = new Slider ({
-			id: "t5_1Val",
-			startVal: 5,
-			minVal: t5_1Extent[0],
-			maxVal: t5_1Extent[1],
-			stepVal: 1,
-			label: "Test 5 slider 1",
-			format: String.fromCharCode(0x2007/*figure space*/) + '>2f',
-		}, eventManager);
+    t4_2Slide.draw(d3.select("#t4_2slider"));
+    
+    var t4_1Readout = new Readout ({
+            node: d3.select("#t4_1val"),
+            id: "t4_1Read",
+            startVal: test4function(t4_1Slide.getValue()),
+            readOnly: true,
+            size: 10,
+        }, eventManager);
+        
+    var t4_2Readout = new Readout ({
+            node: d3.select("#t4_2val"),
+            id: "t4_2Read",
+            startVal: test4function(t4_2Slide.getValue()),
+            readOnly: true,
+            size: 10,
+        }, eventManager);
+        
+    function test4function (input)
+    {
+        return d3.round(input, 2);
+    }
+    
+    eventManager.subscribe(t4_1Slide.changedValueEventId, t4handleChangedValue);
+    eventManager.subscribe(t4_2Slide.changedValueEventId, t4handleChangedValue);
+    
+    function t4handleChangedValue (newValue)
+    {
+        newVal1 = test4function(t4_1Slide.getValue());
+        newVal2 = test4function(t4_2Slide.getValue());
+        
+        t4_1Readout.setValue(newVal1);
+        t4_2Readout.setValue(newVal2);
+    }
+    
+    ///////////////////////////////////////////////
+    
+    // Test 5: Three sliders, one readout
+    var t5_1Extent = [0, 10],
+        t5_2Extent = [0, 20],
+        t5_3Extent = [1, 5];
+        
+    var t5_1Slide = new Slider ({
+            id: "t5_1Val",
+            startVal: 5,
+            minVal: t5_1Extent[0],
+            maxVal: t5_1Extent[1],
+            stepVal: 1,
+            label: "Test 5 slider 1",
+            format: String.fromCharCode(0x2007/*figure space*/) + '>2f',
+        }, eventManager);
 
-	t5_1Slide.draw(d3.select("#t5_1slider"));
+    t5_1Slide.draw(d3.select("#t5_1slider"));
 
-	var t5_2Slide = new Slider ({
-			id: "t5_2Val",
-			startVal: 10,
-			minVal: t5_2Extent[0],
-			maxVal: t5_2Extent[1],
-			stepVal: 1,
-			label: "Test 5 slider 2",
-			format: String.fromCharCode(0x2007/*figure space*/) + '>2f',
-		}, eventManager);
+    var t5_2Slide = new Slider ({
+            id: "t5_2Val",
+            startVal: 10,
+            minVal: t5_2Extent[0],
+            maxVal: t5_2Extent[1],
+            stepVal: 1,
+            label: "Test 5 slider 2",
+            format: String.fromCharCode(0x2007/*figure space*/) + '>2f',
+        }, eventManager);
 
-	t5_2Slide.draw(d3.select("#t5_2slider"));
-	
-	var t5_3Slide = new Slider ({
-			id: "t5_3Val",
-			startVal: 1,
-			minVal: t5_3Extent[0],
-			maxVal: t5_3Extent[1],
-			stepVal: 1,
-			label: "Test 5 slider 3",
-			format: String.fromCharCode(0x2007/*figure space*/) + '>2f',
-		}, eventManager);
-		
-	t5_3Slide.draw(d3.select("#t5_3slider"));
-	
-	var t5Readout = new Readout ({
-			node: d3.select("#t5val"),
-			id: "t5Read",
-			startVal: test5function(t5_1Slide.getValue(), t5_2Slide.getValue(), t5_3Slide.getValue()),
-			readOnly: true,
-			size: 10,
-		}, eventManager);
-		
-	function test5function (input1, input2, input3)
-	{
-		return d3.round(((d3.round(input1, 2) + d3.round(input2, 2)) / d3.round(input3, 2)), 2);
-	}
-	
-	eventManager.subscribe(t5_1Slide.changedValueEventId, t5handleChangedValue);
-	eventManager.subscribe(t5_2Slide.changedValueEventId, t5handleChangedValue);
-	eventManager.subscribe(t5_3Slide.changedValueEventId, t5handleChangedValue);
-	
-	function t5handleChangedValue (newValue)
-	{
-		newVal = test5function(t5_1Slide.getValue(), t5_2Slide.getValue(), t5_3Slide.getValue());
-		t5Readout.setValue(newVal);
-	}
-	
-	////////////////////////////////////////////////
-	
-	// Test 6: One readout, no slider
-	var t6Readout = new Readout ({
-			node: d3.select("#t6val"),
-			id: "t6Read",
-			startVal: 5,
-			readOnly: true,
-			size: 10
-		}, eventManager);
-		
-	////////////////////////////////////////////////
-	
-	// Test 7: Two half-sized sliders
-	var t7_1Extent = [0, 10],
-		t7_2Extent = [0, 10];
-		
-	var t7_1Slide = new Slider ({
-			id: "t7_1Val",
-			startVal: 1,
-			minVal: t7_1Extent[0],
-			maxVal: t7_1Extent[1],
-			stepVal: 1,
-			label: "Test 7 slider 1",
-			format: '5.2f',
-		}, eventManager);
-		
-	t7_1Slide.draw(d3.select("#t7_1slider"));
-	
-	var t7_2Slide = new Slider ({
-			id: "t7_2Val",
-			startVal: 1,
-			minVal: t7_2Extent[0],
-			maxVal: t7_2Extent[1],
-			stepVal: 1,
-			label: "Test 7 slider 2",
-			format: '5.2f',
-		}, eventManager);
-		
-	t7_2Slide.draw(d3.select("#t7_2slider"));
-	
-	////////////////////////////////////////////////
-	
-	// Test 8: Slider next to readout
-	var t8Extent = [0, 10];
-		
-	var t8Slide = new Slider ({
-			id: "t8Val",
-			startVal: 1,
-			minVal: t8Extent[0],
-			maxVal: t8Extent[1],
-			stepVal: 1,
-			label: "Test 8 slider",
-			format: '5.2f',
-		}, eventManager);
-		
-	t8Slide.draw(d3.select("#t8slider"));
-	
-	var t8Readout = new Readout ({
-			node: d3.select("#t8val"),
-			id: "t8Read",
-			startVal: test8function(t8Slide.getValue()),
-			readOnly: true,
-			size: 10
-		}, eventManager);
-		
-	function test8function (input)
-	{
-		return d3.round(input, 2);
-	}
+    t5_2Slide.draw(d3.select("#t5_2slider"));
+    
+    var t5_3Slide = new Slider ({
+            id: "t5_3Val",
+            startVal: 1,
+            minVal: t5_3Extent[0],
+            maxVal: t5_3Extent[1],
+            stepVal: 1,
+            label: "Test 5 slider 3",
+            format: String.fromCharCode(0x2007/*figure space*/) + '>2f',
+        }, eventManager);
+        
+    t5_3Slide.draw(d3.select("#t5_3slider"));
+    
+    var t5Readout = new Readout ({
+            node: d3.select("#t5val"),
+            id: "t5Read",
+            startVal: test5function(t5_1Slide.getValue(), t5_2Slide.getValue(), t5_3Slide.getValue()),
+            readOnly: true,
+            size: 10,
+        }, eventManager);
+        
+    function test5function (input1, input2, input3)
+    {
+        return d3.round(((d3.round(input1, 2) + d3.round(input2, 2)) / d3.round(input3, 2)), 2);
+    }
+    
+    eventManager.subscribe(t5_1Slide.changedValueEventId, t5handleChangedValue);
+    eventManager.subscribe(t5_2Slide.changedValueEventId, t5handleChangedValue);
+    eventManager.subscribe(t5_3Slide.changedValueEventId, t5handleChangedValue);
+    
+    function t5handleChangedValue (newValue)
+    {
+        newVal = test5function(t5_1Slide.getValue(), t5_2Slide.getValue(), t5_3Slide.getValue());
+        t5Readout.setValue(newVal);
+    }
+    
+    ////////////////////////////////////////////////
+    
+    // Test 6: One readout, no slider
+    var t6Readout = new Readout ({
+            node: d3.select("#t6val"),
+            id: "t6Read",
+            startVal: 5,
+            readOnly: true,
+            size: 10
+        }, eventManager);
+        
+    ////////////////////////////////////////////////
+    
+    // Test 7: Two half-sized sliders
+    var t7_1Extent = [0, 10],
+        t7_2Extent = [0, 10];
+        
+    var t7_1Slide = new Slider ({
+            id: "t7_1Val",
+            startVal: 1,
+            minVal: t7_1Extent[0],
+            maxVal: t7_1Extent[1],
+            stepVal: 1,
+            label: "Test 7 slider 1",
+            format: '5.2f',
+        }, eventManager);
+        
+    t7_1Slide.draw(d3.select("#t7_1slider"));
+    
+    var t7_2Slide = new Slider ({
+            id: "t7_2Val",
+            startVal: 1,
+            minVal: t7_2Extent[0],
+            maxVal: t7_2Extent[1],
+            stepVal: 1,
+            label: "Test 7 slider 2",
+            format: '5.2f',
+        }, eventManager);
+        
+    t7_2Slide.draw(d3.select("#t7_2slider"));
+    
+    ////////////////////////////////////////////////
+    
+    // Test 8: Slider next to readout
+    var t8Extent = [0, 10];
+        
+    var t8Slide = new Slider ({
+            id: "t8Val",
+            startVal: 1,
+            minVal: t8Extent[0],
+            maxVal: t8Extent[1],
+            stepVal: 1,
+            label: "Test 8 slider",
+            format: '5.2f',
+        }, eventManager);
+        
+    t8Slide.draw(d3.select("#t8slider"));
+    
+    var t8Readout = new Readout ({
+            node: d3.select("#t8val"),
+            id: "t8Read",
+            startVal: test8function(t8Slide.getValue()),
+            readOnly: true,
+            size: 10
+        }, eventManager);
+        
+    function test8function (input)
+    {
+        return d3.round(input, 2);
+    }
 
-	eventManager.subscribe(t8Slide.changedValueEventId, t8handleChangedValue);
+    eventManager.subscribe(t8Slide.changedValueEventId, t8handleChangedValue);
 
-	function t8handleChangedValue (newValue)
-	{
-		newVal = test8function(t8Slide.getValue());
-		t8Readout.setValue(newVal);
-	}
-	
-	////////////////////////////////////////////////
-	
-	// Test 9: Two sliders next to each other
-	var t9_1Extent = [0, 10],
-		t9_2Extent = [0, 10];
-		
-	var t9_1Slide = new Slider ({
-			id: "t9_1Val",
-			startVal: 1,
-			minVal: t9_1Extent[0],
-			maxVal: t9_1Extent[1],
-			stepVal: 1,
-			label: "Test 9 slider 1",
-			format: '5.2f',
-		}, eventManager);
-		
-	t9_1Slide.draw(d3.select("#t9_1slider"));
-	
-	var t9_2Slide = new Slider ({
-			id: "t9_2Val",
-			startVal: 1,
-			minVal: t9_2Extent[0],
-			maxVal: t9_2Extent[1],
-			stepVal: 1,
-			label: "Test 9 slider 2",
-			format: '5.2f',
-		}, eventManager);
-		
-	t9_2Slide.draw(d3.select("#t9_2slider"));
-	
-	/////////////////////////////////////////////////
-	
-	// Test 10: One slider controlling another
-	var t10_1Extent = [0, 100],
-		t10_2Extent = [0, 100];
-		
-	var t10_1Slide = new Slider ({
-			id: "t10_1Val",
-			startVal: 50,
-			minVal: t10_1Extent[0],
-			maxVal: t10_1Extent[1],
-			stepVal: .1,
-			label: "Test 10 slider 1",
-			format: '5.2f',
-		}, eventManager);
-		
-	t10_1Slide.draw(d3.select("#t10_1slider"));
-	
-	var t10_1Readout = new Readout ({
-			node: d3.select("#t10_1val"),
-			id: "t10_1Read",
-			startVal: test10function(t10_1Slide.getValue()),
-			readOnly: true,
-			size: 10
-		}, eventManager);
-	
-	var t10_2Slide = new Slider ({
-			id: "t10_2Val",
-			startVal: 50,
-			minVal: t10_2Extent[0],
-			maxVal: t10_2Extent[1],
-			stepVal: .1,
-			label: "Test 10 slider 2",
-			format: '5.2f',
-		}, eventManager);
-		
-	t10_2Slide.draw(d3.select("#t10_2slider"));
-	
-	var t10_2Readout = new Readout ({
-			node: d3.select("#t10_2val"),
-			id: "t10_2Read",
-			startVal: test10function(t10_2Slide.getValue()),
-			readOnly: true,
-			size: 10
-		}, eventManager);
-	
-	function test10function (input)
-	{
-		return d3.round(input, 2);
-	}
-	
-	eventManager.subscribe(t10_1Slide.changedValueEventId, handleInputValueChanged1);
-	eventManager.subscribe(t10_2Slide.changedValueEventId, handleInputValueChanged2);
-		
-	function handleInputValueChanged1()
-	{
-		t10_2Slide.setValue(test10function(100 - t10_1Slide.getValue()));
-		t10_2Readout.setValue(test10function(t10_2Slide.getValue()));
-		t10_1Readout.setValue(test10function(t10_1Slide.getValue()));
-	}
-	
-	function handleInputValueChanged2()
-	{
-		t10_1Slide.setValue(test10function(100 - t10_2Slide.getValue()));
-		t10_1Readout.setValue(test10function(t10_1Slide.getValue()));
-		t10_2Readout.setValue(test10function(t10_2Slide.getValue()));
-	}
+    function t8handleChangedValue (newValue)
+    {
+        newVal = test8function(t8Slide.getValue());
+        t8Readout.setValue(newVal);
+    }
+    
+    ////////////////////////////////////////////////
+    
+    // Test 9: Two sliders next to each other
+    var t9_1Extent = [0, 10],
+        t9_2Extent = [0, 10];
+        
+    var t9_1Slide = new Slider ({
+            id: "t9_1Val",
+            startVal: 1,
+            minVal: t9_1Extent[0],
+            maxVal: t9_1Extent[1],
+            stepVal: 1,
+            label: "Test 9 slider 1",
+            format: '5.2f',
+        }, eventManager);
+        
+    t9_1Slide.draw(d3.select("#t9_1slider"));
+    
+    var t9_2Slide = new Slider ({
+            id: "t9_2Val",
+            startVal: 1,
+            minVal: t9_2Extent[0],
+            maxVal: t9_2Extent[1],
+            stepVal: 1,
+            label: "Test 9 slider 2",
+            format: '5.2f',
+        }, eventManager);
+        
+    t9_2Slide.draw(d3.select("#t9_2slider"));
+    
+    /////////////////////////////////////////////////
+    
+    // Test 10: One slider controlling another
+    var t10_1Extent = [0, 100],
+        t10_2Extent = [0, 100];
+        
+    var t10_1Slide = new Slider ({
+            id: "t10_1Val",
+            startVal: 50,
+            minVal: t10_1Extent[0],
+            maxVal: t10_1Extent[1],
+            stepVal: .1,
+            label: "Test 10 slider 1",
+            format: '5.2f',
+        }, eventManager);
+        
+    t10_1Slide.draw(d3.select("#t10_1slider"));
+    
+    var t10_1Readout = new Readout ({
+            node: d3.select("#t10_1val"),
+            id: "t10_1Read",
+            startVal: test10function(t10_1Slide.getValue()),
+            readOnly: true,
+            size: 10
+        }, eventManager);
+    
+    var t10_2Slide = new Slider ({
+            id: "t10_2Val",
+            startVal: 50,
+            minVal: t10_2Extent[0],
+            maxVal: t10_2Extent[1],
+            stepVal: .1,
+            label: "Test 10 slider 2",
+            format: '5.2f',
+        }, eventManager);
+        
+    t10_2Slide.draw(d3.select("#t10_2slider"));
+    
+    var t10_2Readout = new Readout ({
+            node: d3.select("#t10_2val"),
+            id: "t10_2Read",
+            startVal: test10function(t10_2Slide.getValue()),
+            readOnly: true,
+            size: 10
+        }, eventManager);
+    
+    function test10function (input)
+    {
+        return d3.round(input, 2);
+    }
+    
+    eventManager.subscribe(t10_1Slide.changedValueEventId, handleInputValueChanged1);
+    eventManager.subscribe(t10_2Slide.changedValueEventId, handleInputValueChanged2);
+        
+    function handleInputValueChanged1()
+    {
+        t10_2Slide.setValue(test10function(100 - t10_1Slide.getValue()));
+        t10_2Readout.setValue(test10function(t10_2Slide.getValue()));
+        t10_1Readout.setValue(test10function(t10_1Slide.getValue()));
+    }
+    
+    function handleInputValueChanged2()
+    {
+        t10_1Slide.setValue(test10function(100 - t10_2Slide.getValue()));
+        t10_1Readout.setValue(test10function(t10_1Slide.getValue()));
+        t10_2Readout.setValue(test10function(t10_2Slide.getValue()));
+    }
 
 </script>
 </body>

--- a/sliderTests.html
+++ b/sliderTests.html
@@ -32,7 +32,7 @@
                     <div class="lc_ec_leading">
                 <div class="test">
                     <p>Test 0: One slider, no readout</p>
-                    <span id="t0slider"></span>
+                    Slider: <span id="t0slider"></span>
                 </div>
                 
                 <div class="test">
@@ -144,6 +144,8 @@
     
     <script src="../closure/closure-library/closure/goog/base.js"></script>
     <script src="../closure/closure-library/closure/goog/deps.js"></script>
+    <script src="../closure/closure-library/closure/goog/debug/logger.js"></script>
+    <script src="../closure/closure-library/closure/goog/debug/console.js"></script>
 
     <script src="js/eventmanager.js"></script>
     <script src="js/fakeactivitydb.js"></script>
@@ -170,7 +172,11 @@
     <script src="js/widget-numericquestion.js"></script>
     <script src="js/widget-slider.js"></script>
 
-
+    <script>
+    var debugConsole = new goog.debug.Console();
+    debugConsole.setCapturing(true);
+    goog.debug.Logger.getLogger('pearson').setLevel(goog.debug.Logger.Level.FINER);
+    </script>
 <script>
     // local aliases for convenience
     var EventManager = pearson.utils.EventManager;

--- a/sliderTests.html
+++ b/sliderTests.html
@@ -36,12 +36,12 @@
                     </h2>
                     <div class="lc_ec_leading">
                 <div class="test">
-                    <p>Test 0: One slider (fixed size), no readout</p>
+                    <p>Test 0: One slider, fixed bric width, internal readout with appended 'degree' unit. No external readout</p>
                     Slider: <span id="t0slider"></span>
                 </div>
                 
                 <div class="test">
-                    <p>Test 1: Two sliders, no readout</p>
+                    <p>Test 1: Two sliders, internal readout with prepend unit. No external readout</p>
                     <div id="t1sliders">
                         <span id="t1_1slider"></span>
                         <span id="t1_2slider"></span>
@@ -49,13 +49,13 @@
                 </div>
                 
                 <div class="test">
-                    <p>Test 2: One slider, one readout</p>
+                    <p>Test 2: One slider, no format, micron unit appended. One external readout</p>
                     <span id="t2slider"></span>
                     <p>Test 2 slider value = <span id="t2val"></span></p>
                 </div>
                 
                 <div class="test">
-                    <p>Test 3: Two sliders, one readout</p>
+                    <p>Test 3: Two sliders. One external calculated readout</p>
                     <div id="t3sliders">
                         <span id="t3_1slider"></span>
                         <span id="t3_2slider"></span>
@@ -64,7 +64,7 @@
                 </div>
                 
                 <div class="test">
-                    <p>Test 4: Two sliders, two readouts</p>
+                    <p>Test 4: Two sliders. Two external readouts</p>
                     <div id="t4sliders">
                         <span id="t4_1slider"></span>
                         <span id="t4_2slider"></span>
@@ -74,7 +74,7 @@
                 </div>
                 
                 <div class="test">
-                    <p>Test 5: Three sliders, one readout</p>
+                    <p>Test 5: Three sliders, step value of one. One readout</p>
                     <div id="t5sliders">
                         <span id="t5_1slider"></span><br />
                         <span id="t5_2slider"></span><br />
@@ -100,7 +100,7 @@
             <div class="lc_ec_trailing">
                 
                 <div class="test">
-                    <p>Test 8: Slider next to readout</p>
+                    <p>Test 8: Slider next to external readout</p>
                     <div >
                         Slider value = <span id="t8val"></span>
                         <span id="t8slider"></span>
@@ -108,7 +108,7 @@
                 </div>
                 
                 <div class="test">
-                    <p>Test 9: Two sliders next to each other</p>
+                    <p>Test 9: Two sliders next to each other (side by side)</p>
                     <div id="t9sliders">
                         <span id="t9_1slider"></span>
                         <span id="t9_2slider"></span>
@@ -245,6 +245,9 @@
             minVal: t1_2Extent[0],
             maxVal: t1_2Extent[1],
             stepVal: .01,
+            format: '5.2f',
+            unit: '$',
+            unitOpt: pearson.brix.UnitOpt.PREPEND,
             label: "Test 1 slider 2",
         }, eventManager);
         
@@ -262,7 +265,6 @@
             maxVal: t2Extent[1],
             stepVal: .01,
             label: "Test 2 slider",
-            format: '5.2f',
             unit: 'µ',
         }, eventManager);
         
@@ -531,6 +533,7 @@
             stepVal: 1,
             label: "Test 8 slider",
             format: '5.2f',
+            width: '200px'
         }, eventManager);
         
     t8Slide.draw(d3.select("#t8slider"));

--- a/sliderTests.html
+++ b/sliderTests.html
@@ -36,7 +36,7 @@
                     </h2>
                     <div class="lc_ec_leading">
                 <div class="test">
-                    <p>Test 0: One slider, no readout</p>
+                    <p>Test 0: One slider (fixed size), no readout</p>
                     Slider: <span id="t0slider"></span>
                 </div>
                 
@@ -212,7 +212,8 @@
             maxVal: t0Extent[1],
             stepVal: .01,
             label: "Test 0 slider",
-            format: '5.2f',
+            format: '>5.2f',
+            width: '200px',
             unit: '&deg;'
         }, eventManager);
     
@@ -230,6 +231,9 @@
             minVal: t1_1Extent[0],
             maxVal: t1_1Extent[1],
             stepVal: .01,
+            format: '5.2f',
+            unit: '$',
+            unitOpt: pearson.brix.UnitOpt.PREPEND,
             label: "Test 1 slider 1",
         }, eventManager);
         
@@ -494,7 +498,7 @@
             minVal: t7_1Extent[0],
             maxVal: t7_1Extent[1],
             stepVal: 1,
-            width: 100,
+            width: '40%',
             label: "Test7 sldr 1",
             format: '5.2f',
         }, eventManager);
@@ -507,7 +511,7 @@
             minVal: t7_2Extent[0],
             maxVal: t7_2Extent[1],
             stepVal: 1,
-            width: 100,
+            width: '40%',
             label: "Test7 sldr 2",
             format: '5.2f',
         }, eventManager);
@@ -566,6 +570,7 @@
             stepVal: 100,
             label: "Test 9 slider 1",
             format: '5.2f',
+            width: '43%'
         }, eventManager);
         
     t9_1Slide.draw(d3.select("#t9_1slider"));
@@ -575,8 +580,10 @@
             startVal: t9_2Extent[0],
             minVal: t9_2Extent[0],
             maxVal: t9_2Extent[1],
+            stepVal: 0.01,
             label: "Test 9 slider 2",
             format: '5.2f',
+            width: '43%'
         }, eventManager);
         
     t9_2Slide.draw(d3.select("#t9_2slider"));

--- a/test/index.html
+++ b/test/index.html
@@ -82,6 +82,7 @@
     <script src="spec/widget-multiplechoicequestion-spec.js"></script>
     <script src="spec/widget-multiselectquestion-spec.js"></script>
     <script src="spec/widget-sketch-spec.js"></script>
+    <script src="spec/bric-slider-spec.js"></script>
     <script src="spec/submitmanager-spec.js"></script>
 	<script src="spec/widget-barchart-spec.js"></script>
     <script src="spec/mortar-hilite-spec.js"></script>

--- a/test/spec/bric-slider-spec.js
+++ b/test/spec/bric-slider-spec.js
@@ -79,7 +79,11 @@ goog.require('goog.testing.events');
                     expect(mySlider.lastdrawn.widgetGroup.node()).to.deep.equal(last.node());
                 });
 
-                describe('setting value', function () {
+                it.skip('should enable/disable', function(){
+
+                });
+
+                describe('Value Setter', function () {
                     it('should publish the Slider.valueChangeEventId with new value', function () {
                         var valueToSet = 2;
                         var prevValue = mySlider.getValue();
@@ -111,7 +115,7 @@ goog.require('goog.testing.events');
                 });
 
 
-                describe('Events handling', function () {
+                describe('Event handler', function () {
 
                     it('should change value when dragged, and all three events must be published', function() {
                         var changeWasPublished = false;

--- a/test/spec/bric-slider-spec.js
+++ b/test/spec/bric-slider-spec.js
@@ -10,6 +10,8 @@
  * Copyright (c) 2013 Pearson, All rights reserved.
  *
  * **************************************************************************/
+
+// Requires for simulating events
 goog.require('goog.style');
 goog.require('goog.testing.events');
 
@@ -21,7 +23,21 @@ goog.require('goog.testing.events');
     var EventManager = pearson.utils.EventManager;
     var Slider = pearson.brix.Slider;
 
-    describe('Sliders: broadcasting for an answer', function () {
+    var moveSlider = function(slider, delta)
+    {
+        var googSlider = slider.lastdrawn.sliderObj;
+        var offset = goog.style.getPageOffset(googSlider.valueThumb);
+        var size = goog.style.getSize(googSlider.valueThumb);
+        offset.x += size.width / 2;
+        offset.y += size.height / 2;
+
+        goog.testing.events.fireMouseDownEvent(googSlider.valueThumb);
+        offset.x += size.width * delta;
+        goog.testing.events.fireMouseMoveEvent(googSlider.valueThumb, offset);
+        goog.testing.events.fireMouseUpEvent(googSlider.valueThumb);
+    };
+
+    describe('Sliders Bric', function () {
         var eventManager = null;
 
         describe('Creating a Slider w/ 4 choices', function () {
@@ -30,8 +46,8 @@ goog.require('goog.testing.events');
                     id: "t1_1Val",
                     startVal: 0.5,
                     minVal: 0,
-                    maxVal: 5,
-                    stepVal: .01,
+                    maxVal: 10,
+                    stepVal: 0.1,
                     label: "Test Slider",
                     format: '5.2f',
                 };
@@ -79,8 +95,24 @@ goog.require('goog.testing.events');
                     expect(mySlider.lastdrawn.widgetGroup.node()).to.deep.equal(last.node());
                 });
 
-                it.skip('should enable/disable', function(){
+                it('should not alter value when disabled', function(){
+                    // Check that a slider is enabled by default
+                    expect(mySlider.isEnabled()).to.be.true;
 
+                    var valToSet = 5;
+                    mySlider.setValue(valToSet);
+                    expect(mySlider.getValue()).to.equal(valToSet);
+
+                    // Disable the slider and check its state
+                    mySlider.setEnabled(false);
+                    // setValue should work unaffected even when the slider is disabled.
+                    moveSlider(mySlider, 3);
+                    expect(mySlider.getValue()).to.equal(valToSet);
+
+                    mySlider.setEnabled(true);
+                    moveSlider(mySlider, 3);
+                    expect(mySlider.getValue()).to.not.equal(valToSet);
+                    console.log('Slider new val:'+ mySlider.getValue());
                 });
 
                 describe('Value Setter', function () {
@@ -102,7 +134,7 @@ goog.require('goog.testing.events');
                     });
 
                     it('should not change when the value is outside the min-max range', function() {
-                        var valueToSet = 10;
+                        var valueToSet = sliderConfig + 1;
                         var prevValue = mySlider.getValue();
                         var stub = sinon.stub(eventManager, "publish", function(topic, evtDetails) {
                             throw new Error("Should not have published when value outside of valid range");
@@ -135,16 +167,8 @@ goog.require('goog.testing.events');
                         });
 
                         var theVal =  mySlider.getValue();
-                        var googSlider = mySlider.lastdrawn.sliderObj;
-                        var offset = goog.style.getPageOffset(googSlider.valueThumb);
-                        var size = goog.style.getSize(googSlider.valueThumb);
-                        offset.x += size.width / 2;
-                        offset.y += size.height / 2;
-
-                        goog.testing.events.fireMouseDownEvent(googSlider.valueThumb);
-                        offset.x += size.width * 3;
-                        goog.testing.events.fireMouseMoveEvent(googSlider.valueThumb, offset);
-                        goog.testing.events.fireMouseUpEvent(googSlider.valueThumb);
+                        
+                        moveSlider(mySlider, 3);
 
                         expect(changeWasPublished).to.equal(true);
                         expect(startWasPublished).to.equal(true);

--- a/test/spec/bric-slider-spec.js
+++ b/test/spec/bric-slider-spec.js
@@ -1,0 +1,166 @@
+/* **************************************************************************
+ * widget-slider-spec.js                                                $
+ * **********************************************************************//**
+ *
+ * @fileoverview Slider bric unit tests
+ *
+ * Created on       November 7, 2013
+ * @author          Young-Suk Ahn
+ *
+ * Copyright (c) 2013 Pearson, All rights reserved.
+ *
+ * **************************************************************************/
+goog.require('goog.style');
+goog.require('goog.testing.events');
+
+'use strict';
+
+(function () {
+    var expect = chai.expect;
+
+    var EventManager = pearson.utils.EventManager;
+    var Slider = pearson.brix.Slider;
+
+    describe('Sliders: broadcasting for an answer', function () {
+        var eventManager = null;
+
+        describe('Creating a Slider w/ 4 choices', function () {
+            var sliderConfig =
+                {
+                    id: "t1_1Val",
+                    startVal: 0.5,
+                    minVal: 0,
+                    maxVal: 5,
+                    stepVal: .01,
+                    label: "Test Slider",
+                    format: '5.2f',
+                };
+    
+            var mySlider = null;
+            var selectEventCount = 0;
+            var lastSelectEventDetails = null;
+
+            before(function () {
+                eventManager = new EventManager();
+                selectEventCount = 0;
+                lastSelectEventDetails = null;
+
+                mySlider = new Slider(sliderConfig, eventManager);
+            });
+            
+            it('should have the id that was specified in the config', function () {
+                expect(mySlider.id).to.equal(sliderConfig.id);
+            });
+
+            it('should have the eventManager given to the constructor', function () {
+                expect(mySlider.eventManager).to.equal(eventManager);
+            });
+
+            it('should have an uninitialized lastdrawn property', function () {
+                expect(mySlider.lastdrawn).to.have.property('container').that.is.null;
+                expect(mySlider.lastdrawn).to.have.property('widgetGroup').that.is.null;
+                expect(mySlider.lastdrawn).to.have.property('value').that.is.null;
+            });
+
+            describe('Exposed methods', function () {
+                var cntrNode = null;
+
+                before(function () {
+                    cntrNode = helper.createNewDiv();
+                    mySlider.draw(d3.select(cntrNode));
+                });
+                
+                it('should have appended a div element with class \'brixSlider-container\' to the container' +
+                   ' and set the lastdrawn.widgetGroup to that d3 selection after draw()', function () {
+                    // get the last element of the container
+                    var last = d3.select(cntrNode).select(":last-child");
+                    expect(last.node().nodeName).to.equal('DIV');
+                    expect(last.classed('bricSlider-container'), 'has class bricSlider-container').to.be.true;
+                    expect(mySlider.lastdrawn.widgetGroup.node()).to.deep.equal(last.node());
+                });
+
+                describe('setting value', function () {
+                    it('should publish the Slider.valueChangeEventId with new value', function () {
+                        var valueToSet = 2;
+                        var prevValue = mySlider.getValue();
+
+                        var wasPublished = false;
+                        var stub = sinon.stub(eventManager, "publish", function(topic, evtDetails) {
+                            expect(topic).to.equal(mySlider.changedValueEventId);
+                            //expect(evtDetails).to.have.property('oldValue').that.equals(prevValue);
+                            expect(evtDetails).to.have.property('newValue').that.equals(valueToSet);
+                            wasPublished = true;
+                        });
+                        mySlider.setValue(valueToSet);
+                        expect(mySlider.getValue()).is.equal(valueToSet);
+                        expect(wasPublished).to.equal(true);
+                        stub.restore();
+                    });
+
+                    it('should not change when the value is outside the min-max range', function() {
+                        var valueToSet = 10;
+                        var prevValue = mySlider.getValue();
+                        var stub = sinon.stub(eventManager, "publish", function(topic, evtDetails) {
+                            throw new Error("Should not have published when value outside of valid range");
+                        });
+                        mySlider.setValue(valueToSet);
+                        expect(mySlider.getValue()).is.equal(prevValue);
+                        stub.restore();
+                    });
+
+                });
+
+
+                describe('Events handling', function () {
+
+                    it('should change value when dragged, and all three events must be published', function() {
+                        var changeWasPublished = false;
+                        var startWasPublished = false;
+                        var endWasPublished = false;
+                        var stub = sinon.stub(eventManager, "publish", function(topic, evtDetails) {
+                            if (topic == mySlider.changedValueEventId)
+                            {
+                                changeWasPublished = true;
+                            } else if (topic == mySlider.dragStartEventId)
+                            {
+                                startWasPublished = true;
+                            } else if (topic == mySlider.dragEndEventId)
+                            {
+                                endWasPublished = true;
+                            }
+                        });
+
+                        var theVal =  mySlider.getValue();
+                        var googSlider = mySlider.lastdrawn.sliderObj;
+                        var offset = goog.style.getPageOffset(googSlider.valueThumb);
+                        var size = goog.style.getSize(googSlider.valueThumb);
+                        offset.x += size.width / 2;
+                        offset.y += size.height / 2;
+
+                        goog.testing.events.fireMouseDownEvent(googSlider.valueThumb);
+                        offset.x += size.width * 3;
+                        goog.testing.events.fireMouseMoveEvent(googSlider.valueThumb, offset);
+                        goog.testing.events.fireMouseUpEvent(googSlider.valueThumb);
+
+                        expect(changeWasPublished).to.equal(true);
+                        expect(startWasPublished).to.equal(true);
+                        expect(endWasPublished).to.equal(true);
+                    });
+
+                    it.skip('MANUAL TEST: should correctly step', function() {
+                    });
+                    
+                });
+
+
+                after(function () {
+                    // Clean up test modifications to the DOM
+                    cntrNode && d3.select(cntrNode).remove();
+                });
+
+            });
+
+            
+        });
+    });
+})();


### PR DESCRIPTION
@mlippert Slider Ready for code review. (No warning when compiled, except for the sample config).

Implements Slider using Google Closure.
The width configuration is string of format NN{px|%} E.g. : 90%, 200px.
@lbondaryk  I modified the EnergyParabola.html. See if is close to what you want.

Known issues:
- The dragStart and dragEnd events are fired twice.
- Decimal as boundaries does not work.

Not implemented:
- Mark traversed. Possible implementation is to create another div that expands/contracts with the thumb. Whenever the thumb div is moved, the Slider should calculate (on-the-fly) the new size of the traversed area.  Google closure's TwoThumb seems to have this capability already it will have thumbs.
- The Readout that appears on mouse over on the thumb.
