### PR TITLE
1709 deploy on qa

### DIFF
--- a/test/integration/pafjson/addingtopaf-samples.sh
+++ b/test/integration/pafjson/addingtopaf-samples.sh
@@ -67,3 +67,8 @@ java -jar brix-tool-pafclient-0.1-jar-with-dependencies.jar -m PUT \
 # To retrieve: notice the -m GET
 java -jar brix-tool-pafclient-0.1-jar-with-dependencies.jar -m GET \
 	-u http://repo.paf.cert.pearsoncmg.com/paf-repo/resources/activities/test.sanvan.assign.mcq1b -c
+
+
+##########
+# Adding content located as remote resource
+paf-post-activity.sh https://raw.github.com/lbondaryk/brixContent/master/Marin/Other/E3.1.activity.json

--- a/test/integration/pafjson/paf-post-activity.sh
+++ b/test/integration/pafjson/paf-post-activity.sh
@@ -1,0 +1,4 @@
+java -jar brix-tool-pafclient-0.2-jar-with-dependencies.jar -m POST \
+	-h "Content-Type: application/vnd.pearson.paf.v1.envelope+json;body=\"application/vnd.pearson.sanvan.v1.activity\"\"" \
+	-d $1 \
+	-u http://repo.paf.cert.pearsoncmg.com/paf-repo/resources/activities -c

--- a/test/integration/pafjson/paf-post-assignment.sh
+++ b/test/integration/pafjson/paf-post-assignment.sh
@@ -1,0 +1,4 @@
+java -jar brix-tool-pafclient-0.2-jar-with-dependencies.jar -m POST \
+	-h "Content-Type: application/vnd.pearson.paf.v1.envelope+json;body=\"application/vnd.pearson.paf.v1.assignment+json\"\"" \
+	-d $1 \
+	-u http://repo.paf.cert.pearsoncmg.com/paf-repo/resources/activities -c


### PR DESCRIPTION
Please get the new version of pafclient tool from here:
https://hub.pearson.com/confluence/display/EC/Adding+SanVan+content+to+PAF (under "Tool to make signed requests")

You should be able to import content (plain text) in the web.
