### PR TITLE
Removed the code that was renaming the student submission key property t...

### DIFF
--- a/js/answerman.js
+++ b/js/answerman.js
@@ -127,8 +127,6 @@ pearson.brix.utils.IpsAnswerMan.prototype.scoreAnswer = function (seqNodeKey, st
     // Currently the IPS correctness engine expects the key property to be named 'submission'
     var ipsStudentAnswer = {};
     goog.object.extend(ipsStudentAnswer, studentAnswer);
-    ipsStudentAnswer['submission'] = ipsStudentAnswer['key'];
-    delete ipsStudentAnswer['key'];
 
     var timestamp = (new Date()).toISOString();
     var param =


### PR DESCRIPTION
@seannives, here's the client change removing the rename of key to submission.

The name change was to support the correctness engine which has now been changed to expect a 'key' property not a 'submission' property for multiple choice.
